### PR TITLE
Review: feasibility notes and fast-path planning updates

### DIFF
--- a/docs/notes/2026-03-20_05-05-50.md
+++ b/docs/notes/2026-03-20_05-05-50.md
@@ -1,0 +1,33 @@
+**Verdict**
+
+Yes, this is feasible, with one important qualifier: it is feasible as a robust pipeline for born-digital PDFs that produces good Markdown most of the time, not as a guaranteed high-fidelity converter for every document layout.
+
+The core design is sound:
+- Chunking large PDFs is the right approach for memory stability and tool reliability, as described in spec.md and technical-design.md.
+- Primary extraction through GROBID with pdfminer fallback is a realistic failure-tolerant strategy, covered in technical-design.md, technical-design.md, and task-7.2-failure-isolation.md.
+- The plan is staged sensibly, and the project is still at planning stage according to README.md.
+
+**What is Feasible vs Risky**
+
+Feasible for a v1:
+- PDF validation, page counting, splitting, extraction orchestration, Markdown conversion, merge, TOC generation, validation, and failure reporting. Those are standard engineering tasks and the docs describe them clearly.
+- Cross-platform execution is realistic because the design consistently calls for pathlib and subprocess rather than shell-dependent scripts, see spec.md to spec.md and technical-design.md.
+
+Risky or heuristic-heavy:
+- Table reinsertion is the weakest part of the design. The docs explicitly admit it may require manual review and call it the most heuristic-heavy task in the pipeline, see technical-design.md and task-5.3-table-merging.md.
+- The optional LLM path is feasible, but it is a second product, not a small add-on. The hard parts are the explicit overlap requirement between adjacent segments, the need to de-duplicate overlapping output, and the requirement to avoid stripping intentionally repeated content such as headings, all of which are called out in task-9.3-llm-chunking.md.
+- Original PDF indexes and bookmarks will not survive in a meaningful way, and the docs are correct to reset expectations there, see spec.md and technical-design.md.
+
+**Gaps to Fix in the Docs**
+
+A few things should be tightened before implementation:
+- There is a documented contradiction on merge implementation. The spec says merging must be done in Python, not with shell cat, in spec.md, but both the spec merge example and the technical design still show shell cat examples in spec.md and technical-design.md. The technical design later restates the Python-only rule in technical-design.md. That should be made consistent.
+- GROBID versioning is inconsistent. The spec uses `lfoppiano/grobid:latest` in the primary extractor description, the example `docker run` command, and the dependency table, while the technical design switches to a pinned `lfoppiano/grobid:0.8.1` image for both the runtime example and the GitHub Actions service definition. For a real implementation, the pinned version approach is the right one.
+- The quality expectations should be stated more narrowly. The docs already hint at manual review for complex layouts, but the top-level goal language could better distinguish reliable text extraction from best-effort structure preservation.
+
+If you want the short engineering answer: build stages 1 through 8 first, treat table placement as best-effort, and postpone the LLM pipeline until the deterministic path is working. That version is feasible. The full vision is also feasible, but only if you accept that tables, complex layouts, and index reconstruction remain approximate.
+
+Natural next steps:
+1. I can review the plan task-by-task and mark which items are ready to implement as written versus which need doc changes first.
+2. I can turn this into a reduced-scope v1 implementation plan that removes the highest-risk pieces.
+3. I can start the project scaffold and implement stage 1 now.

--- a/docs/notes/2026-03-20_05-05-50.md
+++ b/docs/notes/2026-03-20_05-05-50.md
@@ -21,8 +21,8 @@ Risky or heuristic-heavy:
 **Gaps to Fix in the Docs**
 
 A few things should be tightened before implementation:
-- There is a documented contradiction on merge implementation. The spec says merging must be done in Python, not with shell cat, in spec.md, but both the spec merge example and the technical design still show shell cat examples in spec.md and technical-design.md. The technical design later restates the Python-only rule in technical-design.md. That should be made consistent.
-- GROBID versioning is inconsistent. The spec uses `lfoppiano/grobid:latest` in the primary extractor description, the example `docker run` command, and the dependency table, while the technical design switches to a pinned `lfoppiano/grobid:0.8.1` image for both the runtime example and the GitHub Actions service definition. For a real implementation, the pinned version approach is the right one.
+- Merge guidance has since been aligned: the spec and technical design now both show Python-based merge pseudocode rather than shell `cat`, which resolves the earlier contradiction noted during review.
+- GROBID versioning has since been aligned on the pinned `lfoppiano/grobid:0.8.1` image in the spec and technical design, which resolves the earlier version mismatch noted during review.
 - The quality expectations should be stated more narrowly. The docs already hint at manual review for complex layouts, but the top-level goal language could better distinguish reliable text extraction from best-effort structure preservation.
 
 If you want the short engineering answer: build stages 1 through 8 first, treat table placement as best-effort, and postpone the LLM pipeline until the deterministic path is working. That version is feasible. The full vision is also feasible, but only if you accept that tables, complex layouts, and index reconstruction remain approximate.

--- a/docs/notes/2026-03-20_05-52-39.md
+++ b/docs/notes/2026-03-20_05-52-39.md
@@ -18,11 +18,11 @@ The core pipeline (Stages 1–8) is solidly designed and buildable. The tools ch
 | **External dependencies** | ⚠️ Medium | 9+ system tools (qpdf, Pandoc, Ghostscript, OpenCV, Docker, etc.). Installation/version compatibility will be the #1 user friction point. |
 | **Parallelism (Stage 7)** | ⚠️ Medium | `ThreadPoolExecutor` is fine for I/O-bound work, but GROBID connection contention and the binary all-fail abort logic need tightening. |
 
-### Doc issues to fix before implementing
+### Review issues now resolved
 
-1. **Merge implementation contradiction** — spec says use Python (not shell `cat`), but both spec and technical design show `cat` examples. Make consistent.
-2. **GROBID version** — spec uses `:latest`, technical design pins `:0.8.1`. Pin it everywhere.
-3. **Chunk naming** — 3-digit padding caps at 999 chunks. A 50,000-page PDF at 50 pages/chunk = 1,000 chunks. Bump to 4 digits.
+1. **Merge implementation** — the docs now consistently show Python-based merge pseudocode rather than shell `cat` examples.
+2. **GROBID version** — the docs now consistently pin `lfoppiano/grobid:0.8.1` rather than mixing pinned and `:latest` references.
+3. **Chunk naming** — the docs now use 4-digit chunk numbering, which avoids the 999-chunk ceiling from the earlier 3-digit convention.
 
 ### Recommended approach
 

--- a/docs/notes/2026-03-20_05-52-39.md
+++ b/docs/notes/2026-03-20_05-52-39.md
@@ -1,0 +1,31 @@
+## Feasibility Verdict: **Yes, with caveats**
+
+The core pipeline (Stages 1–8) is solidly designed and buildable. The tools chosen (qpdf, GROBID, Pandoc, pdfminer) are proven for this kind of work, and the chunking strategy is the right call for 300+ MB PDFs. The plan is well-structured — 25 tasks, 158 acceptance criteria, sensible dependency ordering.
+
+### What's straightforward
+
+- **Stages 1–4, 6, 8** (setup, splitting, extraction, conversion, merging, validation) — standard engineering. The docs describe them clearly with concrete commands, APIs, and error handling.
+- **Cross-platform** design is realistic — consistent use of `pathlib`, `subprocess` with list args, Python-based file merging.
+- **Failure isolation** model (skip failed chunks, continue, report) is pragmatic.
+
+### What's risky
+
+| Area | Risk | Why |
+|------|------|-----|
+| **Task 5.3 — Table merging** | 🚩 High | Docs explicitly call it "most heuristic-heavy." Mapping table page positions back into Markdown via text context matching is fragile. Expect iteration. |
+| **Stage 9 — LLM pipeline** | 🚩 High | It's a second product, not an add-on. Token estimation (1:4 char ratio) is approximate, overlap de-duplication is probabilistic, and there's no cost budget enforcement. |
+| **GROBID orchestration (3.1/3.3)** | ⚠️ Medium | Multi-layer retry logic + health polling + "is GROBID entirely dead?" detection = lots of edge cases. |
+| **External dependencies** | ⚠️ Medium | 9+ system tools (qpdf, Pandoc, Ghostscript, OpenCV, Docker, etc.). Installation/version compatibility will be the #1 user friction point. |
+| **Parallelism (Stage 7)** | ⚠️ Medium | `ThreadPoolExecutor` is fine for I/O-bound work, but GROBID connection contention and the binary all-fail abort logic need tightening. |
+
+### Doc issues to fix before implementing
+
+1. **Merge implementation contradiction** — spec says use Python (not shell `cat`), but both spec and technical design show `cat` examples. Make consistent.
+2. **GROBID version** — spec uses `:latest`, technical design pins `:0.8.1`. Pin it everywhere.
+3. **Chunk naming** — 3-digit padding caps at 999 chunks. A 50,000-page PDF at 50 pages/chunk = 1,000 chunks. Bump to 4 digits.
+
+### Recommended approach
+
+Build **Stages 1–4, 6, 8** first as a working v1. Treat table merging (Stage 5) as best-effort. Defer the LLM pipeline (Stage 9) entirely until the deterministic path works end-to-end. This gets you a usable tool with the lowest risk.
+
+I see you already have a similar assessment in 2026-03-20_05-05-50.md — my reading of the full task files confirms that analysis. The plan is thorough and the project is buildable. The main question isn't "can this work" but "how much polish do tables and LLM cleanup need" — and those can iterate after the core ships.

--- a/docs/plan/fast-path-01.md
+++ b/docs/plan/fast-path-01.md
@@ -1,4 +1,4 @@
-# DocDown — Fast-Path Implementation Plan
+# DocDown — Fast-Path 01 (Quality-First MVP)
 
 ## Motivation
 
@@ -132,7 +132,7 @@ Task 7.2 (failure isolation) is deferred to Phase 2 with the worker pool, but Ph
 
 ### Integration note — worker pool retrofit
 
-Task 7.1 wraps the existing sequential `extract → convert → cleanup → tables` per-chunk pipeline from Phase 1 in a `ThreadPoolExecutor`. The per-chunk function (`process_single_chunk`) is already clean from Phase 1; the worker pool is purely additive. No Phase 1 code needs restructuring — only a new outer loop is needed.
+Task 7.1 parallelises the per-chunk pipeline assembled by the end of Phase 2: `extract → convert → cleanup → tables`. Phase 1 already establishes the sequential `process_single_chunk` shape without table extraction, and Phase 2 extends that function with tasks 5.1–5.3 before wrapping it in a `ThreadPoolExecutor`. No earlier task needs to be redefined; the worker pool is an additive outer loop.
 
 ---
 
@@ -160,7 +160,7 @@ Task 7.1 wraps the existing sequential `extract → convert → cleanup → tabl
 
 ## Summary comparison
 
-| | Original plan | Fast path |
+| | Original plan | Fast path 01 |
 |---|---|---|
 | Total tasks | 25 | 25 (same) |
 | Tasks modified | — | 0 |

--- a/docs/plan/fast-path-01.md
+++ b/docs/plan/fast-path-01.md
@@ -1,0 +1,172 @@
+# DocDown — Fast-Path Implementation Plan
+
+## Motivation
+
+The original plan has 25 tasks across 9 stages, ordered strictly stage-by-stage. This alternative groups them into three delivery phases. Each phase produces a working pipeline that can be tested with real PDFs. All original tasks are preserved and fully implemented — nothing is cut, only reordered.
+
+The key changes from the original ordering:
+
+1. **Phase 1 (MVP)** delivers a working end-to-end pipeline with 16 tasks.
+2. **Phase 2 (Enrich)** adds table extraction, parallelism, and optional TOC extraction.
+3. **Phase 3 (LLM)** adds the alternative LLM-assisted pipeline.
+4. Within each phase, independent tasks are flagged for **parallel development** where their dependencies allow it.
+
+---
+
+## Phase 1 — Working End-to-End Pipeline
+
+**Goal:** Convert a PDF to Markdown with GROBID extraction, pdfminer fallback, validation, and a generated TOC. Chunks are processed sequentially. No table extraction.
+
+**Exit criteria:** Running `docdown input.pdf` produces `final.md` with a TOC and a run summary.
+
+### Task order
+
+```
+1.1 Project structure
+ ├─► 1.2 Configuration ──► 1.4 Workdir management ──► 2.1 PDF validation ──► 2.2 Chunk splitting
+ └─► 1.3 Logging
+           │
+           ▼ (after 1.3 + 1.4)
+     ┌─────┴─────┬───────────┐
+     ▼           ▼           ▼        ← parallel development
+   3.1 GROBID  3.2 pdfminer 4.1 Pandoc conversion
+     │           │           │
+     └─────┬─────┘           │
+           ▼                 ▼
+   3.3 Extraction orch.   4.2 Markdown cleanup
+           │                 │
+           └────────┬────────┘
+                    ▼
+              6.1 Chunk merging
+                    │
+                    ▼
+              6.2 TOC generation
+                    │
+                    ▼
+           ┌────────┴────────┐
+           ▼                 ▼        ← parallel development
+     8.1 Chunk validation  8.2 Final validation
+                             │
+                             ▼
+                    8.3 Run summary
+```
+
+### Parallelism opportunities
+
+| Parallel set | Tasks | Why independent |
+|---|---|---|
+| A | 1.2, 1.3 | Both depend only on 1.1 |
+| B | 3.1, 3.2, 4.1 | All depend on 1.3+1.4; no cross-dependency |
+| C | 8.1, 8.2 | 8.1 validates chunks (needs 4.2); 8.2 validates final (needs 6.2). Both are read-only checks. |
+
+### Tasks included (16)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 1.1 | Initialize project structure | Unchanged |
+| 1.2 | Configuration system | Unchanged |
+| 1.3 | Logging framework | Unchanged |
+| 1.4 | Working directory management | Unchanged |
+| 2.1 | PDF validation & page counting | Unchanged |
+| 2.2 | Chunk splitting with qpdf | Unchanged |
+| 3.1 | GROBID integration | Unchanged |
+| 3.2 | pdfminer.six fallback extraction | Unchanged |
+| 3.3 | Extraction orchestration & fallback logic | Unchanged |
+| 4.1 | Pandoc conversion | Unchanged |
+| 4.2 | Post-conversion Markdown cleanup | Unchanged |
+| 6.1 | Chunk merging | Unchanged |
+| 6.2 | TOC generation | Unchanged |
+| 8.1 | Per-chunk validation | Unchanged |
+| 8.2 | Final output validation | Unchanged |
+| 8.3 | Run summary generation | Unchanged |
+
+### What Phase 1 skips (deferred, not removed)
+
+| Deferred task | Why safe to defer |
+|---|---|
+| 5.1–5.3 (Tables) | GROBID + Pandoc already extract tables best-effort. Camelot adds quality but isn't required for a working pipeline. |
+| 6.3 (Pre-split TOC) | Explicitly optional in the original plan. |
+| 7.1–7.2 (Parallelism) | Sequential processing works correctly. Parallelism is a performance optimization. |
+| 9.1–9.3 (LLM) | Entirely independent alternative path. |
+
+### Integration note — failure isolation in Phase 1
+
+Task 7.2 (failure isolation) is deferred to Phase 2 with the worker pool, but Phase 1 still needs basic error handling in the sequential chunk loop. The extraction orchestration (3.3) already tracks per-chunk success/failure and the sequential loop should skip failed chunks at merge time (6.1 already handles this via placeholder comments). No additional task is needed — 3.3 and 6.1 cover it.
+
+---
+
+## Phase 2 — Tables, Parallelism & Polish
+
+**Goal:** Add Camelot table extraction, parallel chunk processing, and optional pre-split TOC extraction. After this phase, the pipeline matches the full spec minus LLM.
+
+**Exit criteria:** Tables are extracted and merged into Markdown. Chunks process in parallel with proper failure isolation.
+
+### Task order
+
+```
+5.1 Table detection ──► 5.2 Table-to-Markdown ──► 5.3 Table merging
+                                                        │
+                                                        ▼
+7.1 Worker pool (depends on 3.3 + 4.2 + 5.3) ──► 7.2 Failure isolation
+
+6.3 Pre-split TOC extraction  ← independent, can be done any time
+```
+
+### Parallelism opportunities
+
+| Parallel set | Tasks | Why independent |
+|---|---|---|
+| D | 5.1, 6.3 | 5.1 depends on 1.4; 6.3 depends on 2.1. No overlap. |
+| E | 7.1 (after 5.3), 6.3 (if not done in set D) | Different subsystems. |
+
+### Tasks included (6)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 5.1 | Table detection & extraction with Camelot | Unchanged |
+| 5.2 | Table-to-Markdown conversion | Unchanged |
+| 5.3 | Table merging into chunk Markdown | Unchanged |
+| 6.3 | Pre-split TOC extraction (optional) | Unchanged |
+| 7.1 | Worker pool implementation | Unchanged |
+| 7.2 | Failure isolation & reporting | Unchanged |
+
+### Integration note — worker pool retrofit
+
+Task 7.1 wraps the existing sequential `extract → convert → cleanup → tables` per-chunk pipeline from Phase 1 in a `ThreadPoolExecutor`. The per-chunk function (`process_single_chunk`) is already clean from Phase 1; the worker pool is purely additive. No Phase 1 code needs restructuring — only a new outer loop is needed.
+
+---
+
+## Phase 3 — LLM-Assisted Pipeline
+
+**Goal:** Add the alternative LLM cleanup path for poorly-structured PDFs.
+
+**Exit criteria:** Running `docdown input.pdf --llm-cleanup` uses PyMuPDF + LLM instead of GROBID + Pandoc.
+
+### Task order
+
+```
+9.1 PyMuPDF extraction ──► 9.2 LLM integration ──► 9.3 Context-window chunking
+```
+
+### Tasks included (3)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 9.1 | PyMuPDF text extraction | Unchanged |
+| 9.2 | LLM integration & prompt design | Unchanged |
+| 9.3 | Context-window chunking & de-duplication | Unchanged |
+
+---
+
+## Summary comparison
+
+| | Original plan | Fast path |
+|---|---|---|
+| Total tasks | 25 | 25 (same) |
+| Tasks modified | — | 0 |
+| Phases | 1 | 3 |
+| Tasks to working E2E | 25 (all stages required) | 16 (Phase 1) |
+| First testable output | After Stage 8 | After Phase 1 |
+| Table extraction | Required before merge | Deferred to Phase 2 |
+| Parallelism | Required before validation | Deferred to Phase 2 |
+| LLM pipeline | Mixed into main plan | Isolated as Phase 3 |

--- a/docs/plan/fast-path-01.md
+++ b/docs/plan/fast-path-01.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-The original plan has 25 tasks across 9 stages, ordered strictly stage-by-stage. This alternative groups them into three delivery phases. Each phase produces a working pipeline that can be tested with real PDFs. All original tasks are preserved and fully implemented — nothing is cut, only reordered.
+The original plan has 25 tasks across 9 stages, ordered strictly stage-by-stage. This alternative groups them into three delivery phases. Each phase produces a working pipeline that can be tested with real PDFs. All original tasks remain in scope — nothing is cut, only reordered.
 
 The key changes from the original ordering:
 

--- a/docs/plan/fast-path-02.md
+++ b/docs/plan/fast-path-02.md
@@ -1,0 +1,191 @@
+# DocDown — Fast-Path 02 (Fallback-First Baseline)
+
+## Motivation
+
+This alternative optimizes for the shortest route to a testable end-to-end pipeline. It reaches first output sooner than Fast-Path 01 by using the simpler pdfminer-based extraction path before introducing GROBID and extraction orchestration.
+
+All original tasks are still preserved and fully implemented. Nothing is removed. The difference is only delivery order.
+
+The key changes from the original ordering:
+
+1. **Phase 1 (Baseline)** delivers a working end-to-end pipeline with 14 tasks and no Docker dependency.
+2. **Phase 2 (Upgrade Extraction)** adds GROBID and the full primary-plus-fallback orchestration.
+3. **Phase 3 (Enrich)** adds tables, parallelism, and optional pre-split TOC extraction.
+4. **Phase 4 (LLM)** adds the alternative LLM-assisted pipeline.
+
+---
+
+## Phase 1 — Baseline End-to-End Pipeline
+
+**Goal:** Convert a PDF to Markdown with pdfminer extraction, Pandoc conversion, cleanup, merge, validation, and a generated TOC. Chunks are processed sequentially. No GROBID, no tables, no parallelism.
+
+**Exit criteria:** Running `docdown input.pdf` produces `final.md` with a TOC and a run summary, using the pdfminer extraction path only.
+
+### Task order
+
+```
+1.1 Project structure
+ ├─► 1.2 Configuration ──► 1.4 Workdir management ──► 2.1 PDF validation ──► 2.2 Chunk splitting
+ └─► 1.3 Logging
+                                               │
+                                               ▼
+                                      3.2 pdfminer extraction
+                                               │
+                                               ▼
+                                      4.1 Pandoc conversion
+                                               │
+                                               ▼
+                                      4.2 Markdown cleanup
+                                               │
+                                               ▼
+                                         6.1 Chunk merging
+                                               │
+                                               ▼
+                                         6.2 TOC generation
+                                               │
+                                               ▼
+                                  ┌────────────┴────────────┐
+                                  ▼                         ▼
+                            8.1 Chunk validation      8.2 Final validation
+                                                            │
+                                                            ▼
+                                                   8.3 Run summary
+```
+
+### Parallelism opportunities
+
+| Parallel set | Tasks | Why independent |
+|---|---|---|
+| A | 1.2, 1.3 | Both depend only on 1.1. |
+| B | 8.1, 8.2 | 8.1 inspects chunk outputs; 8.2 inspects final output after 6.2. Both are read-only checks. |
+
+### Tasks included (14)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 1.1 | Initialize project structure | Unchanged |
+| 1.2 | Configuration system | Unchanged |
+| 1.3 | Logging framework | Unchanged |
+| 1.4 | Working directory management | Unchanged |
+| 2.1 | PDF validation & page counting | Unchanged |
+| 2.2 | Chunk splitting with qpdf | Unchanged |
+| 3.2 | pdfminer.six fallback extraction | Unchanged |
+| 4.1 | Pandoc conversion | Unchanged |
+| 4.2 | Post-conversion Markdown cleanup | Unchanged |
+| 6.1 | Chunk merging | Unchanged |
+| 6.2 | TOC generation | Unchanged |
+| 8.1 | Per-chunk validation | Unchanged |
+| 8.2 | Final output validation | Unchanged |
+| 8.3 | Run summary generation | Unchanged |
+
+### What Phase 1 skips (deferred, not removed)
+
+| Deferred task | Why safe to defer |
+|---|---|
+| 3.1 (GROBID) | The baseline can ship using the existing pdfminer extraction task first. |
+| 3.3 (Extraction orchestration) | Not needed until both primary and fallback extractors exist in the runnable pipeline. |
+| 5.1–5.3 (Tables) | Table quality improves later, but the pipeline is still testable without Camelot. |
+| 6.3 (Pre-split TOC) | Explicitly optional in the original plan. |
+| 7.1–7.2 (Parallelism) | Sequential execution is sufficient for correctness. |
+| 9.1–9.3 (LLM) | Entirely independent alternative path. |
+
+### Integration note — baseline extraction path
+
+Phase 1 wires the chunk loop directly to task 3.2's plain-text extraction output. That keeps downstream interfaces simple because task 4.1 already accepts plain-text input. When tasks 3.1 and 3.3 are added later, the direct extractor call is replaced by the orchestrator without changing stages 4, 6, or 8.
+
+---
+
+## Phase 2 — Upgrade Extraction Quality
+
+**Goal:** Switch the default pipeline from pdfminer-only extraction to GROBID-first extraction with pdfminer fallback.
+
+**Exit criteria:** Running `docdown input.pdf` uses GROBID when available, falls back to pdfminer when needed, and preserves the same downstream Markdown, validation, and reporting flow from Phase 1.
+
+### Task order
+
+```
+3.1 GROBID integration ──► 3.3 Extraction orchestration
+
+6.3 Pre-split TOC extraction  ← independent, can be done any time after 2.1
+```
+
+### Tasks included (3)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 3.1 | GROBID integration | Unchanged |
+| 3.3 | Extraction orchestration & fallback logic | Unchanged |
+| 6.3 | Pre-split TOC extraction (optional) | Unchanged |
+
+### Integration note — orchestrator retrofit
+
+Task 3.3 becomes the only entry point for extraction. The Phase 1 pdfminer path remains intact as the fallback branch, so no earlier work is discarded.
+
+---
+
+## Phase 3 — Tables, Parallelism & Polish
+
+**Goal:** Add table extraction, table reinsertion, and parallel chunk processing.
+
+**Exit criteria:** Tables are extracted and merged into chunk Markdown, and chunks process in parallel with proper failure isolation.
+
+### Task order
+
+```
+5.1 Table detection ──► 5.2 Table-to-Markdown ──► 5.3 Table merging
+                                                        │
+                                                        ▼
+7.1 Worker pool (depends on 3.3 + 4.2 + 5.3) ──► 7.2 Failure isolation
+```
+
+### Tasks included (5)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 5.1 | Table detection & extraction with Camelot | Unchanged |
+| 5.2 | Table-to-Markdown conversion | Unchanged |
+| 5.3 | Table merging into chunk Markdown | Unchanged |
+| 7.1 | Worker pool implementation | Unchanged |
+| 7.2 | Failure isolation & reporting | Unchanged |
+
+---
+
+## Phase 4 — LLM-Assisted Pipeline
+
+**Goal:** Add the optional LLM-assisted path for poorly structured PDFs.
+
+**Exit criteria:** Running `docdown input.pdf --llm-cleanup` uses PyMuPDF + LLM chunk processing as an alternative pipeline.
+
+### Task order
+
+```
+9.1 PyMuPDF extraction ──► 9.2 LLM integration ──► 9.3 Context-window chunking
+```
+
+### Tasks included (3)
+
+| Task | Title | Status in original plan |
+|---|---|---|
+| 9.1 | PyMuPDF text extraction | Unchanged |
+| 9.2 | LLM integration & prompt design | Unchanged |
+| 9.3 | Context-window chunking & de-duplication | Unchanged |
+
+---
+
+## Summary comparison
+
+| | Original plan | Fast path 01 | Fast path 02 |
+|---|---|---|---|
+| Total tasks | 25 | 25 (same) | 25 (same) |
+| Tasks modified | — | 0 | 0 |
+| Phases | 1 | 3 | 4 |
+| Tasks to working E2E | 25 (all stages required) | 16 | 14 |
+| First testable output | After Stage 8 | GROBID + pdfminer sequential pipeline | pdfminer-only sequential pipeline |
+| Early external dependencies | Docker + GROBID expected early | Docker + GROBID expected in Phase 1 | No Docker required for Phase 1 |
+| Best use case | Strict stage-by-stage execution | Earlier high-quality extraction | Fastest baseline delivery |
+
+## Trade-off summary
+
+- Choose this path when speed of first output matters more than early Markdown quality.
+- This is the lowest-friction route for local development on Windows because Phase 1 does not depend on Docker.
+- Fast-Path 01 is still the better option if early validation must reflect the intended GROBID-first architecture.

--- a/docs/plan/fast-path-02.md
+++ b/docs/plan/fast-path-02.md
@@ -4,7 +4,7 @@
 
 This alternative optimizes for the shortest route to a testable end-to-end pipeline. It reaches first output sooner than Fast-Path 01 by using the simpler pdfminer-based extraction path before introducing GROBID and extraction orchestration.
 
-All original tasks are still preserved and fully implemented. Nothing is removed. The difference is only delivery order.
+All original tasks remain in scope. Nothing is removed. The difference is only delivery order.
 
 The key changes from the original ordering:
 

--- a/docs/plan/non-python-alternatives.md
+++ b/docs/plan/non-python-alternatives.md
@@ -1,0 +1,262 @@
+# DocDown - Alternatives to Python
+
+## Purpose
+
+This note outlines realistic alternatives to a Python implementation for DocDown. The goal is not to change the pipeline itself, but to show which parts can be implemented in other languages, with existing tools, or through external services.
+
+In each option below, the linked tasks are the ones most directly "un-pythonized" by that approach.
+
+## Short recommendation
+
+If the goal is "not Python" without rewriting the whole architecture, the best option is a C# host that keeps `qpdf`, Pandoc, and GROBID as external dependencies and replaces the Python-only libraries case by case.
+
+If the goal is the fastest delivery with the least custom extraction logic, the best option is a managed API approach.
+
+If the goal is to stay fully self-managed without Python, a JVM-based stack is the strongest non-Python alternative because PDFBox and Tabula are mature.
+
+## Option 1 - C# host, existing CLI tools and services
+
+### What it is
+
+Build the pipeline as a .NET console application and keep the existing external tools where they already make sense:
+
+- `qpdf` for validation and splitting
+- GROBID over HTTP for structured extraction
+- Pandoc for Markdown conversion
+- Docker only for running GROBID
+
+This keeps the current architecture mostly intact while moving orchestration, configuration, logging, retries, file handling, and concurrency out of Python.
+
+### Good fit for
+
+- A Windows-heavy team
+- Strong C# experience
+- A desire to keep self-hosted infrastructure
+- Minimal redesign of the current plan
+
+### Suggested implementation stack
+
+- .NET 8 console app
+- `System.CommandLine` for CLI
+- `Microsoft.Extensions.Configuration` for config
+- `Microsoft.Extensions.Logging` or Serilog for logging
+- `HttpClient` plus Polly for GROBID and LLM retries
+- `Parallel.ForEachAsync` or TPL Dataflow for worker-pool behavior
+- `CliWrap` or plain `ProcessStartInfo` for `qpdf` and Pandoc
+
+### Tasks this un-pythonizes directly
+
+- [task-1.1-project-structure.md](task-1.1-project-structure.md)
+- [task-1.2-configuration.md](task-1.2-configuration.md)
+- [task-1.3-logging.md](task-1.3-logging.md)
+- [task-1.4-workdir-management.md](task-1.4-workdir-management.md)
+- [task-2.1-pdf-validation.md](task-2.1-pdf-validation.md)
+- [task-2.2-chunk-splitting.md](task-2.2-chunk-splitting.md)
+- [task-3.1-grobid-integration.md](task-3.1-grobid-integration.md)
+- [task-3.3-extraction-orchestration.md](task-3.3-extraction-orchestration.md)
+- [task-4.1-pandoc-conversion.md](task-4.1-pandoc-conversion.md)
+- [task-4.2-markdown-cleanup.md](task-4.2-markdown-cleanup.md)
+- [task-6.1-chunk-merging.md](task-6.1-chunk-merging.md)
+- [task-6.2-toc-generation.md](task-6.2-toc-generation.md)
+- [task-6.3-pre-split-toc-extraction.md](task-6.3-pre-split-toc-extraction.md)
+- [task-7.1-worker-pool.md](task-7.1-worker-pool.md)
+- [task-7.2-failure-isolation.md](task-7.2-failure-isolation.md)
+- [task-8.1-chunk-validation.md](task-8.1-chunk-validation.md)
+- [task-8.2-final-validation.md](task-8.2-final-validation.md)
+- [task-8.3-run-summary.md](task-8.3-run-summary.md)
+- [task-9.2-llm-integration.md](task-9.2-llm-integration.md)
+- [task-9.3-llm-chunking.md](task-9.3-llm-chunking.md)
+
+### Python-specific tasks that still need replacement choices
+
+- [task-3.2-pdfminer-fallback.md](task-3.2-pdfminer-fallback.md): replace `pdfminer.six` with Poppler `pdftotext`, Apache PDFBox, Apache Tika, or UglyToad.PdfPig.
+- [task-5.1-table-detection.md](task-5.1-table-detection.md): replace Camelot with Tabula-java, a cloud document API, or a custom extractor.
+- [task-5.2-table-to-markdown.md](task-5.2-table-to-markdown.md): implement in C# once table output is available.
+- [task-9.1-pymupdf-extraction.md](task-9.1-pymupdf-extraction.md): replace PyMuPDF with PdfPig, MuPDF bindings for .NET, or PDFBox via a sidecar.
+
+### Main trade-offs
+
+- Lowest disruption to the current design
+- Still depends on non-.NET tools like `qpdf`, Pandoc, and GROBID
+- Table extraction remains the hardest gap because Camelot is a Python-native choice in the current plan
+
+## Option 2 - Full .NET implementation with selective sidecars
+
+### What it is
+
+Keep the application in C#, but try to replace as many Python-era dependencies as possible with .NET libraries or sidecar services.
+
+### Likely replacements
+
+- `pdfminer.six` -> UglyToad.PdfPig, PdfSharp-based readers, or Poppler `pdftotext`
+- PyMuPDF -> PdfPig or MuPDF bindings
+- Camelot -> Tabula-java sidecar or a managed API for tables
+- LLM integration -> direct provider SDK or raw HTTP from C#
+
+### Tasks this most changes
+
+- [task-3.2-pdfminer-fallback.md](task-3.2-pdfminer-fallback.md)
+- [task-5.1-table-detection.md](task-5.1-table-detection.md)
+- [task-5.2-table-to-markdown.md](task-5.2-table-to-markdown.md)
+- [task-5.3-table-merging.md](task-5.3-table-merging.md)
+- [task-9.1-pymupdf-extraction.md](task-9.1-pymupdf-extraction.md)
+- [task-9.2-llm-integration.md](task-9.2-llm-integration.md)
+- [task-9.3-llm-chunking.md](task-9.3-llm-chunking.md)
+
+### Main trade-offs
+
+- Better long-term consistency if the team standardizes on .NET
+- More engineering risk than Option 1 because the extraction stack changes materially
+- You may end up with a sidecar JVM tool anyway for table extraction
+
+## Option 3 - JVM-centric pipeline
+
+### What it is
+
+Build the orchestrator in Java or Kotlin and lean on the JVM PDF ecosystem.
+
+### Why it is credible
+
+The JVM has mature options for several hard parts of this project:
+
+- Apache PDFBox for PDF parsing and text extraction
+- Tabula-java for table extraction
+- Apache Tika for document text extraction abstractions
+- OkHttp or Spring WebClient for GROBID and LLM calls
+
+### Good fit for
+
+- Teams comfortable with Java or Kotlin
+- A preference for self-managed infrastructure over vendor APIs
+- A desire to avoid the Python packaging and runtime story entirely
+
+### Tasks this un-pythonizes most cleanly
+
+- [task-1.1-project-structure.md](task-1.1-project-structure.md)
+- [task-1.2-configuration.md](task-1.2-configuration.md)
+- [task-1.3-logging.md](task-1.3-logging.md)
+- [task-1.4-workdir-management.md](task-1.4-workdir-management.md)
+- [task-2.1-pdf-validation.md](task-2.1-pdf-validation.md)
+- [task-2.2-chunk-splitting.md](task-2.2-chunk-splitting.md)
+- [task-3.1-grobid-integration.md](task-3.1-grobid-integration.md)
+- [task-3.2-pdfminer-fallback.md](task-3.2-pdfminer-fallback.md)
+- [task-3.3-extraction-orchestration.md](task-3.3-extraction-orchestration.md)
+- [task-4.1-pandoc-conversion.md](task-4.1-pandoc-conversion.md)
+- [task-4.2-markdown-cleanup.md](task-4.2-markdown-cleanup.md)
+- [task-5.1-table-detection.md](task-5.1-table-detection.md)
+- [task-5.2-table-to-markdown.md](task-5.2-table-to-markdown.md)
+- [task-5.3-table-merging.md](task-5.3-table-merging.md)
+- [task-6.1-chunk-merging.md](task-6.1-chunk-merging.md)
+- [task-6.2-toc-generation.md](task-6.2-toc-generation.md)
+- [task-6.3-pre-split-toc-extraction.md](task-6.3-pre-split-toc-extraction.md)
+- [task-7.1-worker-pool.md](task-7.1-worker-pool.md)
+- [task-7.2-failure-isolation.md](task-7.2-failure-isolation.md)
+- [task-8.1-chunk-validation.md](task-8.1-chunk-validation.md)
+- [task-8.2-final-validation.md](task-8.2-final-validation.md)
+- [task-8.3-run-summary.md](task-8.3-run-summary.md)
+- [task-9.1-pymupdf-extraction.md](task-9.1-pymupdf-extraction.md)
+- [task-9.2-llm-integration.md](task-9.2-llm-integration.md)
+- [task-9.3-llm-chunking.md](task-9.3-llm-chunking.md)
+
+### Main trade-offs
+
+- Strongest fully self-managed non-Python option
+- More divergence from the current task implementation notes than Option 1
+- Operationally heavier than a pure C# host if your team is mostly .NET
+
+## Option 4 - Managed document APIs
+
+### What it is
+
+Use a thin orchestrator in C#, Node.js, Go, or any other language, but outsource extraction-heavy stages to cloud APIs.
+
+### Typical providers
+
+- Azure AI Document Intelligence
+- Google Document AI
+- AWS Textract
+- Mathpix or similar document-conversion APIs
+- Unstructured API or similar hosted parsing platforms
+
+### Tasks this can replace almost entirely
+
+- [task-3.1-grobid-integration.md](task-3.1-grobid-integration.md)
+- [task-3.2-pdfminer-fallback.md](task-3.2-pdfminer-fallback.md)
+- [task-3.3-extraction-orchestration.md](task-3.3-extraction-orchestration.md)
+- [task-5.1-table-detection.md](task-5.1-table-detection.md)
+- [task-5.2-table-to-markdown.md](task-5.2-table-to-markdown.md)
+- [task-5.3-table-merging.md](task-5.3-table-merging.md)
+- [task-9.1-pymupdf-extraction.md](task-9.1-pymupdf-extraction.md)
+- [task-9.2-llm-integration.md](task-9.2-llm-integration.md)
+- [task-9.3-llm-chunking.md](task-9.3-llm-chunking.md)
+
+### Tasks still needed locally
+
+- [task-1.2-configuration.md](task-1.2-configuration.md)
+- [task-1.3-logging.md](task-1.3-logging.md)
+- [task-1.4-workdir-management.md](task-1.4-workdir-management.md)
+- [task-2.1-pdf-validation.md](task-2.1-pdf-validation.md)
+- [task-2.2-chunk-splitting.md](task-2.2-chunk-splitting.md)
+- [task-4.1-pandoc-conversion.md](task-4.1-pandoc-conversion.md) if the provider does not already return Markdown
+- [task-4.2-markdown-cleanup.md](task-4.2-markdown-cleanup.md)
+- [task-6.1-chunk-merging.md](task-6.1-chunk-merging.md)
+- [task-6.2-toc-generation.md](task-6.2-toc-generation.md)
+- [task-7.1-worker-pool.md](task-7.1-worker-pool.md)
+- [task-7.2-failure-isolation.md](task-7.2-failure-isolation.md)
+- [task-8.1-chunk-validation.md](task-8.1-chunk-validation.md)
+- [task-8.2-final-validation.md](task-8.2-final-validation.md)
+- [task-8.3-run-summary.md](task-8.3-run-summary.md)
+
+### Main trade-offs
+
+- Fastest path to acceptable extraction quality
+- Best option if tables are important early
+- Highest recurring cost and strongest data-governance implications
+- Greater vendor lock-in than the self-hosted options
+
+## Option 5 - Keep Python out of the runtime, not necessarily the toolchain
+
+### What it is
+
+Treat Python-only capabilities as isolated build-time or sidecar tools, while the main application is written in C# or another language.
+
+Examples:
+
+- Run Camelot as a separate worker service and call it over HTTP
+- Run a small Python extraction helper process only for table detection
+- Keep the core CLI, orchestration, logging, and packaging in C#
+
+### Tasks this isolates rather than rewrites
+
+- [task-3.2-pdfminer-fallback.md](task-3.2-pdfminer-fallback.md)
+- [task-5.1-table-detection.md](task-5.1-table-detection.md)
+- [task-5.2-table-to-markdown.md](task-5.2-table-to-markdown.md)
+- [task-9.1-pymupdf-extraction.md](task-9.1-pymupdf-extraction.md)
+
+### Main trade-offs
+
+- Pragmatic if "no Python in the main app" is enough
+- Lower rewrite risk than replacing every Python-oriented tool
+- Still leaves Python somewhere in deployment and operations
+
+## Best-fit summary
+
+| Goal | Best option |
+|---|---|
+| Minimal redesign, non-Python app | Option 1 - C# host plus existing tools |
+| Deep .NET ownership | Option 2 - Full .NET with selective sidecars |
+| Strongest self-managed non-Python stack | Option 3 - JVM-centric pipeline |
+| Fastest delivery and best early extraction quality | Option 4 - Managed document APIs |
+| Keep Python out of the main runtime only | Option 5 - Sidecar isolation |
+
+## Practical recommendation for this repo
+
+If you want a serious non-Python path without throwing away the current planning work, use this sequence:
+
+1. Recast the host application and orchestration tasks in C#.
+2. Keep `qpdf`, Pandoc, and GROBID as external dependencies.
+3. Replace `pdfminer.six` with PDFBox, Poppler `pdftotext`, or PdfPig.
+4. Replace Camelot with Tabula-java or a managed document API.
+5. Keep the LLM path language-agnostic and implement it directly against the provider API.
+
+That preserves most of the current architecture while removing Python from the core implementation.

--- a/docs/plan/overview.md
+++ b/docs/plan/overview.md
@@ -120,6 +120,11 @@ Stage 1 (Setup)
   └──▶ Stage 9 (LLM — optional, independent path)
 ```
 
+## Alternative Delivery Paths
+
+- [fast-path-01.md](fast-path-01.md): quality-first MVP path that reaches a full GROBID plus pdfminer end-to-end pipeline before tables, parallelism, and the LLM option.
+- [fast-path-02.md](fast-path-02.md): fallback-first baseline path that gets to a simpler pdfminer-only end-to-end pipeline even sooner, then layers GROBID, tables, and parallelism afterward.
+
 ## Conventions
 
 - Each task file follows a consistent template: summary, dependencies, acceptance criteria, implementation notes, and references.

--- a/docs/plan/task-1.3-logging.md
+++ b/docs/plan/task-1.3-logging.md
@@ -22,8 +22,8 @@ Set up structured logging with configurable levels, file output, and per-chunk c
 ### Format
 
 ```
-2026-03-19T10:15:32 INFO  [chunk-007] GROBID extraction complete (12.3s)
-2026-03-19T10:15:33 WARN  [chunk-007] Output size below threshold (0.8%)
+2026-03-19T10:15:32 INFO  [chunk-0007] GROBID extraction complete (12.3s)
+2026-03-19T10:15:33 WARN  [chunk-0007] Output size below threshold (0.8%)
 ```
 
 ### Design

--- a/docs/plan/task-1.4-workdir-management.md
+++ b/docs/plan/task-1.4-workdir-management.md
@@ -41,13 +41,13 @@ class WorkDir:
         self.base = base
     
     def chunk_pdf(self, n: int) -> Path:
-        return self.base / "chunks" / f"chunk-{n:03d}.pdf"
+        return self.base / "chunks" / f"chunk-{n:04d}.pdf"
     
     def extracted(self, n: int, ext: str = "xml") -> Path:
-        return self.base / "extracted" / f"chunk-{n:03d}.{ext}"
+        return self.base / "extracted" / f"chunk-{n:04d}.{ext}"
     
     def markdown(self, n: int) -> Path:
-        return self.base / "markdown" / f"chunk-{n:03d}.md"
+        return self.base / "markdown" / f"chunk-{n:04d}.md"
     
     # etc.
 ```

--- a/docs/plan/task-2.2-chunk-splitting.md
+++ b/docs/plan/task-2.2-chunk-splitting.md
@@ -12,7 +12,7 @@ Split the validated PDF into page-range chunks using `qpdf`.
 
 - [ ] PDF is split into chunks of `chunk_size` pages (configurable, default 50).
 - [ ] Last chunk contains the remaining pages (may be smaller than `chunk_size`).
-- [ ] Output files follow naming convention: `chunk-001.pdf`, `chunk-002.pdf`, etc.
+- [ ] Output files follow naming convention: `chunk-0001.pdf`, `chunk-0002.pdf`, etc.
 - [ ] Output files are written to `workdir/chunks/`.
 - [ ] Chunk count is verified: `ceil(total_pages / chunk_size)` chunks exist.
 - [ ] Each chunk is validated as a readable PDF.
@@ -31,7 +31,7 @@ def split_pdf(input_path, chunks_dir, chunk_size, total_pages):
     for i in range(num_chunks):
         start = i * chunk_size + 1
         end = min((i + 1) * chunk_size, total_pages)
-        output = chunks_dir / f"chunk-{i+1:03d}.pdf"
+        output = chunks_dir / f"chunk-{i+1:04d}.pdf"
         subprocess.run([
             "qpdf", str(input_path),
             "--pages", ".", f"{start}-{end}", "--",
@@ -44,7 +44,7 @@ def split_pdf(input_path, chunks_dir, chunk_size, total_pages):
 
 - Single-page PDF → one chunk.
 - PDF with exactly `chunk_size` pages → one chunk.
-- Very large page counts (10,000+) → works; naming supports up to 999 chunks with 3-digit padding. Extend to 4-digit if needed.
+- Very large page counts (10,000+) → works; 4-digit padding supports up to 9,999 chunks.
 
 ## References
 

--- a/docs/plan/task-2.2-chunk-splitting.md
+++ b/docs/plan/task-2.2-chunk-splitting.md
@@ -44,7 +44,7 @@ def split_pdf(input_path, chunks_dir, chunk_size, total_pages):
 
 - Single-page PDF → one chunk.
 - PDF with exactly `chunk_size` pages → one chunk.
-- Very large page counts (10,000+) → works; 4-digit padding supports up to 9,999 chunks.
+- Very large page counts (10,000+) → works as long as the resulting chunk count stays within the fixed-width naming scheme. The current 4-digit convention supports up to 9,999 chunks; if `num_chunks` can exceed that, derive the padding width from `num_chunks` instead of assuming 4 digits.
 
 ## References
 

--- a/docs/plan/task-3.1-grobid-integration.md
+++ b/docs/plan/task-3.1-grobid-integration.md
@@ -13,7 +13,7 @@ Implement the primary content extraction method using GROBID's REST API to conve
 
 - [ ] GROBID service availability is checked before processing (`GET /api/isalive`).
 - [ ] Each chunk PDF is submitted to GROBID's `processFulltextDocument` endpoint.
-- [ ] TEI XML response is written to `workdir/extracted/chunk-NNN.xml`.
+- [ ] TEI XML response is written to `workdir/extracted/chunk-NNNN.xml`.
 - [ ] Per-request timeout is configurable (default: 120 s).
 - [ ] Timeout/503 errors trigger a single retry with 2× timeout (240 s).
 - [ ] Exponential backoff on 503: base 5 s, max 3 retries.

--- a/docs/plan/task-3.2-pdfminer-fallback.md
+++ b/docs/plan/task-3.2-pdfminer-fallback.md
@@ -12,7 +12,7 @@ Implement the fallback content extraction method using `pdfminer.six` for chunks
 ## Acceptance Criteria
 
 - [ ] Text is extracted from a chunk PDF using `pdfminer.six` `extract_text`.
-- [ ] Output is written to `workdir/extracted/chunk-NNN.txt` (note: `.txt`, not `.xml`).
+- [ ] Output is written to `workdir/extracted/chunk-NNNN.txt` (note: `.txt`, not `.xml`).
 - [ ] Output encoding is UTF-8.
 - [ ] Extraction that produces empty output is flagged as a failure.
 - [ ] Extraction errors (e.g., codec errors) are caught, logged, and reported as failure.

--- a/docs/plan/task-3.3-extraction-orchestration.md
+++ b/docs/plan/task-3.3-extraction-orchestration.md
@@ -51,14 +51,14 @@ def extract_chunk(chunk_path, chunk_num, config, workdir):
         path = run_extractor(config.extractor, chunk_path, chunk_num, workdir)
         return ExtractionResult(chunk_num, True, config.extractor, path, None)
     except ExtractionError as e:
-        log.warning(f"[chunk-{chunk_num:03d}] Primary extractor failed: {e}")
+        log.warning(f"[chunk-{chunk_num:04d}] Primary extractor failed: {e}")
     
     # 2. Try fallback
     try:
         path = run_extractor(config.fallback_extractor, chunk_path, chunk_num, workdir)
         return ExtractionResult(chunk_num, True, config.fallback_extractor, path, None)
     except ExtractionError as e:
-        log.error(f"[chunk-{chunk_num:03d}] Fallback extractor failed: {e}")
+        log.error(f"[chunk-{chunk_num:04d}] Fallback extractor failed: {e}")
         return ExtractionResult(chunk_num, False, None, None, str(e))
 ```
 

--- a/docs/plan/task-4.1-pandoc-conversion.md
+++ b/docs/plan/task-4.1-pandoc-conversion.md
@@ -14,7 +14,7 @@ Convert extracted intermediate files (TEI XML or plain text) into GitHub-Flavore
 - [ ] Plain text files (from pdfminer) are converted to GFM Markdown via Pandoc.
 - [ ] Input format is selected based on file extension (`.xml` → TEI, `.txt` → plain).
 - [ ] `--wrap=none` is used to prevent hard line wrapping.
-- [ ] Output is written to `workdir/markdown/chunk-NNN.md`.
+- [ ] Output is written to `workdir/markdown/chunk-NNNN.md`.
 - [ ] Pandoc errors are caught and reported with stderr output.
 - [ ] Conversion time per chunk is logged.
 - [ ] Unit tests verify correct Pandoc flags for each input format.

--- a/docs/plan/task-5.2-table-to-markdown.md
+++ b/docs/plan/task-5.2-table-to-markdown.md
@@ -11,7 +11,7 @@ Convert extracted Camelot table objects into Markdown table syntax.
 ## Acceptance Criteria
 
 - [ ] Each extracted table's DataFrame is converted to a Markdown table string.
-- [ ] Markdown tables are written to `workdir/tables/chunk-NNN-table-MMM.md`.
+- [ ] Markdown tables are written to `workdir/tables/chunk-NNNN-table-MMM.md`.
 - [ ] Empty or single-cell tables are discarded.
 - [ ] Cell content is cleaned: excessive whitespace collapsed, newlines within cells replaced with `<br>`.
 - [ ] Table files include a metadata comment: page number, bounding box, accuracy score.

--- a/docs/plan/task-5.2-table-to-markdown.md
+++ b/docs/plan/task-5.2-table-to-markdown.md
@@ -32,7 +32,7 @@ def table_to_markdown(table, chunk_num, table_num, tables_dir):
     
     md = df.to_markdown(index=False)
     
-    path = tables_dir / f"chunk-{chunk_num:03d}-table-{table_num:03d}.md"
+    path = tables_dir / f"chunk-{chunk_num:04d}-table-{table_num:03d}.md"
     metadata = (
         f"<!-- table: chunk={chunk_num} table={table_num} "
         f"page={table.parsing_report['page']} "

--- a/docs/plan/task-6.1-chunk-merging.md
+++ b/docs/plan/task-6.1-chunk-merging.md
@@ -38,7 +38,7 @@ def merge_chunks(markdown_dir, output_path, total_chunks):
 
 ### Ordering
 
-Rely on the `chunk-NNNN` naming convention. Sort numerically, not lexicographically (avoids `chunk-10` before `chunk-2` issues).
+Rely on the fixed-width `chunk-NNNN` naming convention. With zero-padded chunk numbers, lexicographic ordering is stable, but the implementation should still iterate by chunk number so missing chunks can be represented with placeholder comments.
 
 ## References
 

--- a/docs/plan/task-6.1-chunk-merging.md
+++ b/docs/plan/task-6.1-chunk-merging.md
@@ -12,7 +12,7 @@ Concatenate all chunk Markdown files into a single merged document in correct or
 
 - [ ] All chunk Markdown files in `workdir/markdown/` are concatenated in numeric order.
 - [ ] A horizontal rule (`---`) is inserted between chunks as a visual separator.
-- [ ] Failed/missing chunks are skipped with a placeholder comment: `<!-- chunk-NNNN: extraction failed -->`.
+- [ ] Failed/missing chunks are represented in the merged output with a placeholder comment: `<!-- chunk-NNNN: extraction failed -->`.
 - [ ] Output is written to `workdir/merged.md`.
 - [ ] Total line count and file size of merged output are logged.
 - [ ] Unit tests verify: correct ordering, separator insertion, missing-chunk handling.

--- a/docs/plan/task-6.1-chunk-merging.md
+++ b/docs/plan/task-6.1-chunk-merging.md
@@ -12,7 +12,7 @@ Concatenate all chunk Markdown files into a single merged document in correct or
 
 - [ ] All chunk Markdown files in `workdir/markdown/` are concatenated in numeric order.
 - [ ] A horizontal rule (`---`) is inserted between chunks as a visual separator.
-- [ ] Failed/missing chunks are skipped with a placeholder comment: `<!-- chunk-NNN: extraction failed -->`.
+- [ ] Failed/missing chunks are skipped with a placeholder comment: `<!-- chunk-NNNN: extraction failed -->`.
 - [ ] Output is written to `workdir/merged.md`.
 - [ ] Total line count and file size of merged output are logged.
 - [ ] Unit tests verify: correct ordering, separator insertion, missing-chunk handling.
@@ -37,7 +37,7 @@ def merge_chunks(markdown_dir, output_path, total_chunks):
 
 ### Ordering
 
-Rely on the `chunk-NNN` naming convention. Sort numerically, not lexicographically (avoids `chunk-10` before `chunk-2` issues).
+Rely on the `chunk-NNNN` naming convention. Sort numerically, not lexicographically (avoids `chunk-10` before `chunk-2` issues).
 
 ## References
 

--- a/docs/plan/task-6.1-chunk-merging.md
+++ b/docs/plan/task-6.1-chunk-merging.md
@@ -32,7 +32,8 @@ def merge_chunks(markdown_dir, output_path, total_chunks):
             parts.append(f"<!-- chunk-{i:04d}: extraction failed -->\n")
     
     merged = "\n\n---\n\n".join(parts)
-    output_path.write_text(merged, encoding="utf-8")
+    with output_path.open("w", encoding="utf-8", newline="") as f:
+        f.write(merged)
 ```
 
 ### Ordering

--- a/docs/plan/task-6.1-chunk-merging.md
+++ b/docs/plan/task-6.1-chunk-merging.md
@@ -25,11 +25,11 @@ Concatenate all chunk Markdown files into a single merged document in correct or
 def merge_chunks(markdown_dir, output_path, total_chunks):
     parts = []
     for i in range(1, total_chunks + 1):
-        chunk_path = markdown_dir / f"chunk-{i:03d}.md"
+        chunk_path = markdown_dir / f"chunk-{i:04d}.md"
         if chunk_path.exists() and chunk_path.stat().st_size > 0:
             parts.append(chunk_path.read_text(encoding="utf-8"))
         else:
-            parts.append(f"<!-- chunk-{i:03d}: extraction failed -->\n")
+            parts.append(f"<!-- chunk-{i:04d}: extraction failed -->\n")
     
     merged = "\n\n---\n\n".join(parts)
     output_path.write_text(merged, encoding="utf-8")

--- a/docs/plan/task-7.1-worker-pool.md
+++ b/docs/plan/task-7.1-worker-pool.md
@@ -43,7 +43,7 @@ def process_chunks_parallel(chunk_paths, config, workdir):
                 result = future.result()
                 results.append(result)
             except Exception as e:
-                log.error(f"[chunk-{chunk_num:03d}] Unhandled error: {e}")
+                log.error(f"[chunk-{chunk_num:04d}] Unhandled error: {e}")
                 results.append(ChunkResult(chunk_num, success=False, error=str(e)))
     return sorted(results, key=lambda r: r.chunk_number)
 ```

--- a/docs/plan/task-7.2-failure-isolation.md
+++ b/docs/plan/task-7.2-failure-isolation.md
@@ -45,7 +45,7 @@ def log_failure_summary(results):
     
     log.warning(f"{len(failed)} chunk(s) failed:")
     for r in failed:
-        log.warning(f"  chunk-{r.chunk_number:03d}: {r.failed_stage} — {r.error}")
+        log.warning(f"  chunk-{r.chunk_number:04d}: {r.failed_stage} — {r.error}")
     
     if len(failed) == len(results):
         raise FatalPipelineError("All chunks failed. No output produced.")

--- a/docs/plan/task-8.3-run-summary.md
+++ b/docs/plan/task-8.3-run-summary.md
@@ -41,7 +41,7 @@ def generate_summary(run_context):
     failed_details = ""
     if run_context.failed_chunks:
         details = "; ".join(
-            f"chunk-{r.chunk_number:03d}: {r.error}"
+            f"chunk-{r.chunk_number:04d}: {r.error}"
             for r in run_context.failed_chunks
         )
         failed_details = f" ({details})"

--- a/docs/plan/task-8.3-run-summary.md
+++ b/docs/plan/task-8.3-run-summary.md
@@ -27,7 +27,7 @@ DocDown Run Summary
 Input:          source.pdf (342 MB, 1847 pages)
 Chunks:         37
 Successful:     36
-Failed:         1 (chunk-023: GROBID timeout + pdfminer encoding error)
+Failed:         1 (chunk-0023: GROBID timeout + pdfminer encoding error)
 Tables found:   14
 Output:         final.md (4.2 MB)
 Duration:       12m 34s

--- a/docs/pre-investigation.md
+++ b/docs/pre-investigation.md
@@ -22,7 +22,7 @@ Use:
 Example:
 
 ```bash
-qpdf input.pdf --split-pages=50 chunk-%03d.pdf
+qpdf input.pdf --split-pages=50 chunk-%04d.pdf
 ```
 
 👉 This creates manageable ~50-page chunks.
@@ -46,7 +46,7 @@ GROBID
 Run via Docker:
 
 ```bash
-docker run -p 8070:8070 lfoppiano/grobid:latest
+docker run -p 8070:8070 lfoppiano/grobid:0.8.1
 ```
 
 Then process each chunk.
@@ -103,8 +103,9 @@ Add:
 
 ## 5) Merge everything back
 
-```bash
-cat chunk-*.md > final.md
+```python
+for md_path in sorted(markdown_dir.glob("chunk-*.md")):
+  out.write(md_path.read_text(encoding="utf-8"))
 ```
 
 ---
@@ -209,8 +210,8 @@ There are two very different things people call “index”:
 
 If you split:
 
-* chunk-001 → pages 1–50
-* chunk-002 → pages 51–100
+* chunk-0001 → pages 1–50
+* chunk-0002 → pages 51–100
 
 Then your index still says:
 

--- a/docs/pre-investigation.md
+++ b/docs/pre-investigation.md
@@ -104,8 +104,14 @@ Add:
 ## 5) Merge everything back
 
 ```python
-for md_path in sorted(markdown_dir.glob("chunk-*.md")):
-  out.write(md_path.read_text(encoding="utf-8"))
+# Pseudocode
+parts = [
+  md_path.read_text(encoding="utf-8")
+  for md_path in sorted(markdown_dir.glob("chunk-*.md"))
+]
+
+with output_path.open("w", encoding="utf-8", newline="") as out:
+  out.write("\n\n---\n\n".join(parts))
 ```
 
 ---

--- a/docs/pre-investigation.md
+++ b/docs/pre-investigation.md
@@ -105,10 +105,13 @@ Add:
 
 ```python
 # Pseudocode
-parts = [
-  md_path.read_text(encoding="utf-8")
-  for md_path in sorted(markdown_dir.glob("chunk-*.md"))
-]
+parts = []
+for i in range(1, total_chunks + 1):
+  chunk_path = markdown_dir / f"chunk-{i:04d}.md"
+  if chunk_path.exists() and chunk_path.stat().st_size > 0:
+    parts.append(chunk_path.read_text(encoding="utf-8"))
+  else:
+    parts.append(f"<!-- chunk-{i:04d}: extraction failed -->\n")
 
 with output_path.open("w", encoding="utf-8", newline="") as out:
   out.write("\n\n---\n\n".join(parts))

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -131,7 +131,7 @@ Table output is merged into the corresponding Markdown chunk.
 Concatenate all chunk Markdown files and generate a Table of Contents from headings.
 
 ```python
-# Pseudocode — implemented in Python (see §4.3), not via shell cat
+# Pseudocode — implemented in Python (see §4.3 Cross-Platform Considerations), not via shell cat
 merge_chunks(markdown_dir=Path("markdown"), output_path=Path("merged.md"), total_chunks=n)
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -58,12 +58,12 @@ Split the input PDF into manageable chunks to prevent converter crashes and memo
 | -------------- | ---------------------------- |
 | Tool           | `qpdf` (preferred), `pdftk`  |
 | Chunk size     | ~50 pages                    |
-| Output         | `chunk-NNN.pdf`              |
+| Output         | `chunk-NNNN.pdf`             |
 
 Example:
 
 ```bash
-qpdf input.pdf --split-pages=50 chunk-%03d.pdf
+qpdf input.pdf --split-pages=50 chunk-%04d.pdf
 ```
 
 ### 5.2 Stage 2 — Extract Structured Content
@@ -74,13 +74,13 @@ Extract document structure from each chunk into a structured intermediate format
 
 | Property     | Value                                              |
 | ------------ | -------------------------------------------------- |
-| Tool         | GROBID (Docker: `lfoppiano/grobid:latest`)         |
+| Tool         | GROBID (Docker: `lfoppiano/grobid:0.8.1`)          |
 | Input        | Chunk PDFs                                         |
 | Output       | TEI XML per chunk                                  |
 | Capabilities | Sections, headings, references, semantic structure |
 
 ```bash
-docker run -p 8070:8070 lfoppiano/grobid:latest
+docker run -p 8070:8070 lfoppiano/grobid:0.8.1
 ```
 
 **Fallback method — pdfminer.six:**
@@ -130,8 +130,12 @@ Table output is merged into the corresponding Markdown chunk.
 
 Concatenate all chunk Markdown files and generate a Table of Contents from headings.
 
+```python
+# Implemented in Python (see §4.3) — not via shell cat
+merge_chunks("markdown/chunk-*.md", "merged.md")
+```
+
 ```bash
-cat chunk-*.md > merged.md
 pandoc merged.md --toc -o final.md
 ```
 
@@ -197,7 +201,7 @@ Printed TOC text survives extraction but loses meaning:
 | Tool/Library   | Purpose                     | Install                                |
 | -------------- | --------------------------- | -------------------------------------- |
 | qpdf           | PDF splitting               | Package manager / CLI                  |
-| GROBID         | Structured extraction       | Docker (`lfoppiano/grobid:latest`)     |
+| GROBID         | Structured extraction       | Docker (`lfoppiano/grobid:0.8.1`)      |
 | pdfminer.six   | Fallback text extraction    | `pip install pdfminer.six`             |
 | Pandoc         | Format conversion           | Package manager / CLI                  |
 | Camelot        | Table extraction            | `pip install camelot-py[cv]`           |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -131,8 +131,8 @@ Table output is merged into the corresponding Markdown chunk.
 Concatenate all chunk Markdown files and generate a Table of Contents from headings.
 
 ```python
-# Implemented in Python (see §4.3) — not via shell cat
-merge_chunks("markdown/chunk-*.md", "merged.md")
+# Pseudocode — implemented in Python (see §4.3), not via shell cat
+merge_chunks(markdown_dir=Path("markdown"), output_path=Path("merged.md"), total_chunks=n)
 ```
 
 ```bash

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -29,19 +29,19 @@ workdir/
 ├── input/
 │   └── source.pdf                  # original (or symlink)
 ├── chunks/
-│   ├── chunk-001.pdf
-│   ├── chunk-002.pdf
+│   ├── chunk-0001.pdf
+│   ├── chunk-0002.pdf
 │   └── ...
 ├── extracted/
-│   ├── chunk-001.xml               # TEI XML from GROBID
-│   ├── chunk-002.xml
+│   ├── chunk-0001.xml              # TEI XML from GROBID
+│   ├── chunk-0002.xml
 │   └── ...
 ├── markdown/
-│   ├── chunk-001.md
-│   ├── chunk-002.md
+│   ├── chunk-0001.md
+│   ├── chunk-0002.md
 │   └── ...
 ├── tables/
-│   ├── chunk-003-table-001.md      # extracted tables
+│   ├── chunk-0003-table-001.md     # extracted tables
 │   └── ...
 ├── merged.md                       # concatenated output (no TOC)
 ├── final.md                        # merged output with generated TOC
@@ -84,8 +84,8 @@ validation:
 3. Calculate chunk boundaries based on `chunk_size`.
 4. Split:
    ```bash
-   qpdf input.pdf --pages . 1-50 -- chunks/chunk-001.pdf
-   qpdf input.pdf --pages . 51-100 -- chunks/chunk-002.pdf
+   qpdf input.pdf --pages . 1-50 -- chunks/chunk-0001.pdf
+   qpdf input.pdf --pages . 51-100 -- chunks/chunk-0002.pdf
    # ...
    ```
 5. Verify chunk count × chunk_size ≥ total pages.
@@ -96,7 +96,7 @@ validation:
 - Encrypted PDFs: `qpdf --decrypt` first if a password is available; otherwise abort with a clear error.
 - Corrupted PDFs: `qpdf --check` returns a non-zero exit code → abort and report.
 
-**Outputs:** `chunks/chunk-NNN.pdf`
+**Outputs:** `chunks/chunk-NNNN.pdf`
 
 ---
 
@@ -122,7 +122,7 @@ Use a pinned version tag in production rather than `latest`.
 POST http://localhost:8070/api/processFulltextDocument
 Content-Type: multipart/form-data
 
-input = @chunks/chunk-001.pdf
+input = @chunks/chunk-0001.pdf
 ```
 
 **Response:** TEI XML document.
@@ -132,7 +132,7 @@ input = @chunks/chunk-001.pdf
 - Wait for GROBID readiness before submitting (`GET /api/isalive`).
 - Set a per-request timeout of 120 seconds. Large or complex chunks may take longer; retry once with a 240-second timeout before falling back.
 - GROBID returns HTTP 503 when overloaded. Implement exponential backoff (max 3 retries, base delay 5 s).
-- Store response as `extracted/chunk-NNN.xml`.
+- Store response as `extracted/chunk-NNNN.xml`.
 
 #### 5.2.2 pdfminer.six Extraction (Fallback)
 
@@ -141,8 +141,8 @@ Used when GROBID is unavailable or fails on a specific chunk.
 ```python
 from pdfminer.high_level import extract_text
 
-text = extract_text("chunks/chunk-001.pdf")
-with open("extracted/chunk-001.txt", "w", encoding="utf-8") as f:
+text = extract_text("chunks/chunk-0001.pdf")
+with open("extracted/chunk-0001.txt", "w", encoding="utf-8") as f:
     f.write(text)
 ```
 
@@ -172,13 +172,13 @@ Failed chunks are listed in `run.log` and summarised at the end of the run.
 From TEI XML (GROBID output):
 
 ```bash
-pandoc extracted/chunk-001.xml -f tei -t gfm --wrap=none -o markdown/chunk-001.md
+pandoc extracted/chunk-0001.xml -f tei -t gfm --wrap=none -o markdown/chunk-0001.md
 ```
 
 From plain text (pdfminer fallback):
 
 ```bash
-pandoc extracted/chunk-001.txt -f plain -t gfm --wrap=none -o markdown/chunk-001.md
+pandoc extracted/chunk-0001.txt -f plain -t gfm --wrap=none -o markdown/chunk-0001.md
 ```
 
 **Pandoc flags:**
@@ -209,9 +209,9 @@ For each chunk PDF, attempt table extraction:
 ```python
 import camelot
 
-tables = camelot.read_pdf("chunks/chunk-003.pdf", pages="all", flavor="lattice")
+tables = camelot.read_pdf("chunks/chunk-0003.pdf", pages="all", flavor="lattice")
 if not tables:
-    tables = camelot.read_pdf("chunks/chunk-003.pdf", pages="all", flavor="stream")
+    tables = camelot.read_pdf("chunks/chunk-0003.pdf", pages="all", flavor="stream")
 ```
 
 - Try `lattice` first (for tables with visible cell borders).
@@ -225,7 +225,7 @@ Each extracted table is converted to a Markdown table:
 for i, table in enumerate(tables):
     df = table.df
     md = df.to_markdown(index=False)
-    with open(f"tables/chunk-003-table-{i+1:03d}.md", "w") as f:
+    with open(f"tables/chunk-0003-table-{i+1:03d}.md", "w") as f:
         f.write(md)
 ```
 
@@ -250,9 +250,13 @@ This step may require manual review for complex layouts.
 
 #### 5.5.1 Merge
 
-```bash
-# Ensure correct ordering
-ls markdown/chunk-*.md | sort | xargs cat > merged.md
+Concatenation is implemented in Python (per §11.3 rule 3), not via shell `cat`:
+
+```python
+# Pseudocode — see implementation for full version
+for md_path in sorted(markdown_dir.glob("chunk-*.md")):
+    out.write(md_path.read_text(encoding="utf-8"))
+    out.write("\n\n---\n\n")
 ```
 
 Insert a horizontal rule (`---`) between chunks to preserve visual separation.
@@ -294,7 +298,7 @@ chunk PDF → PyMuPDF (text per page) → LLM cleanup → chunk .md → Merge
 ```python
 import fitz  # PyMuPDF
 
-doc = fitz.open("chunks/chunk-001.pdf")
+doc = fitz.open("chunks/chunk-0001.pdf")
 pages = []
 for page in doc:
     pages.append(page.get_text("text"))
@@ -387,7 +391,7 @@ DocDown Run Summary
 Input:          source.pdf (342 MB, 1847 pages)
 Chunks:         37
 Successful:     36
-Failed:         1 (chunk-023: GROBID timeout + pdfminer encoding error)
+Failed:         1 (chunk-0023: GROBID timeout + pdfminer encoding error)
 Tables found:   14
 Output:         final.md (4.2 MB)
 Duration:       12m 34s
@@ -456,7 +460,7 @@ Python 3.10+ (for `match` statements, `|` union types in type hints, and `pathli
 
 1. **Paths:** Use `pathlib.Path` everywhere. Never concatenate paths with string `/` or `\`.
 2. **Subprocess calls:** Invoke all external tools (`qpdf`, `pandoc`, `pdftk`) via `subprocess.run()` with list arguments (not shell strings). This avoids shell-escaping issues across platforms.
-3. **File merging:** Implement chunk concatenation in Python (`open` / `write`), not via shell `cat`. The bash examples in this document are for illustration only.
+3. **File merging:** Implement chunk concatenation in Python (`open` / `write`), not via shell `cat`.
 4. **Line endings:** Write all output files with `\n` (Unix-style). Use `newline=""` or explicit encoding when writing.
 5. **Docker:** GROBID is accessed over HTTP (`localhost:8070`). Docker availability is checked at startup; if unavailable, the pipeline falls back to pdfminer for all chunks.
 6. **Temp files:** Use `tempfile` module or the working directory — never hardcode `/tmp`.

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -254,9 +254,11 @@ Concatenation is implemented in Python (per §11.3 rule 3), not via shell `cat`:
 
 ```python
 # Pseudocode — see implementation for full version
-for md_path in sorted(markdown_dir.glob("chunk-*.md")):
-    out.write(md_path.read_text(encoding="utf-8"))
-    out.write("\n\n---\n\n")
+parts = [
+  md_path.read_text(encoding="utf-8")
+  for md_path in sorted(markdown_dir.glob("chunk-*.md"))
+]
+out.write("\n\n---\n\n".join(parts))
 ```
 
 Insert a horizontal rule (`---`) between chunks to preserve visual separation.

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -222,12 +222,14 @@ if not tables:
 Each extracted table is converted to a Markdown table:
 
 ```python
+from pathlib import Path
+
 for i, table in enumerate(tables):
     df = table.df
     md = df.to_markdown(index=False)
-  output_path = Path("tables") / f"chunk-0003-table-{i+1:03d}.md"
-  with output_path.open("w", encoding="utf-8", newline="") as f:
-    f.write(md)
+    output_path = Path("tables") / f"chunk-0003-table-{i+1:03d}.md"
+    with output_path.open("w", encoding="utf-8", newline="") as f:
+        f.write(md)
 ```
 
 Requires `tabulate` for `DataFrame.to_markdown()`.

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -225,8 +225,9 @@ Each extracted table is converted to a Markdown table:
 for i, table in enumerate(tables):
     df = table.df
     md = df.to_markdown(index=False)
-    with open(f"tables/chunk-0003-table-{i+1:03d}.md", "w") as f:
-        f.write(md)
+  output_path = Path("tables") / f"chunk-0003-table-{i+1:03d}.md"
+  with output_path.open("w", encoding="utf-8", newline="") as f:
+    f.write(md)
 ```
 
 Requires `tabulate` for `DataFrame.to_markdown()`.

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -258,7 +258,9 @@ parts = [
   md_path.read_text(encoding="utf-8")
   for md_path in sorted(markdown_dir.glob("chunk-*.md"))
 ]
-out.write("\n\n---\n\n".join(parts))
+
+with output_path.open("w", encoding="utf-8", newline="") as out:
+  out.write("\n\n---\n\n".join(parts))
 ```
 
 Insert a horizontal rule (`---`) between chunks to preserve visual separation.

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -254,10 +254,13 @@ Concatenation is implemented in Python (per §11.3 rule 3), not via shell `cat`:
 
 ```python
 # Pseudocode — see implementation for full version
-parts = [
-  md_path.read_text(encoding="utf-8")
-  for md_path in sorted(markdown_dir.glob("chunk-*.md"))
-]
+parts = []
+for i in range(1, total_chunks + 1):
+  chunk_path = markdown_dir / f"chunk-{i:04d}.md"
+  if chunk_path.exists() and chunk_path.stat().st_size > 0:
+    parts.append(chunk_path.read_text(encoding="utf-8"))
+  else:
+    parts.append(f"<!-- chunk-{i:04d}: extraction failed -->\n")
 
 with output_path.open("w", encoding="utf-8", newline="") as out:
   out.write("\n\n---\n\n".join(parts))


### PR DESCRIPTION
## Summary
- add feasibility review notes for the planned PDF-to-Markdown pipeline
- add two alternative fast-path implementation plans and link them from the plan overview
- align documentation on chunk naming, GROBID version pinning, and Python-based merge guidance

## Testing
- not run (documentation-only changes)
