### PR TITLE
Task 1.3: structured logging framework

### DIFF
--- a/docdown.yaml
+++ b/docdown.yaml
@@ -9,6 +9,7 @@ fallback_extractor: pdfminer
 table_extraction: true
 llm_cleanup: false
 llm_model: null
+log_level: INFO
 validation:
   min_output_ratio: 0.01
   max_empty_chunks: 0

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -82,9 +82,18 @@ def main(
         raise click.ClickException("No input PDF provided. Pass INPUT_PDF or set 'input' in docdown.yaml.")
 
     logger = configure_logging(cfg.workdir, cfg.log_level)
-    logger.info("DocDown v%s", _version())
-    logger.info("Input:   %s", cfg.input)
-    logger.info("Workdir: %s", cfg.workdir)
+    version_text = f"DocDown v{_version()}"
+    input_text = f"Input:   {cfg.input}"
+    workdir_text = f"Workdir: {cfg.workdir}"
+
+    # Keep CLI summaries on stdout while also recording them in logs.
+    click.echo(version_text)
+    click.echo(input_text)
+    click.echo(workdir_text)
+
+    logger.info(version_text)
+    logger.info(input_text)
+    logger.info(workdir_text)
 
 
 def _version():

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -3,6 +3,7 @@
 import click
 
 from docdown.config import ConfigError, load_config
+from docdown.utils.logging import configure_logging
 
 
 @click.command()
@@ -28,6 +29,12 @@ from docdown.config import ConfigError, load_config
 @click.option("--table-extraction/--no-table-extraction", default=None, help="Enable table extraction")
 @click.option("--llm-cleanup/--no-llm-cleanup", default=None, help="Enable LLM cleanup pipeline")
 @click.option("--llm-model", type=str, default=None, help="LLM model identifier")
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "WARN"], case_sensitive=False),
+    default=None,
+    help="Log verbosity level",
+)
 @click.option("--min-output-ratio", type=float, default=None, help="Validation minimum output ratio")
 @click.option("--max-empty-chunks", type=int, default=None, help="Validation max empty chunks")
 def main(
@@ -42,6 +49,7 @@ def main(
     table_extraction,
     llm_cleanup,
     llm_model,
+    log_level,
     min_output_ratio,
     max_empty_chunks,
 ):
@@ -58,6 +66,7 @@ def main(
         "table_extraction": table_extraction,
         "llm_cleanup": llm_cleanup,
         "llm_model": llm_model,
+        "log_level": log_level,
         "validation": {
             "min_output_ratio": min_output_ratio,
             "max_empty_chunks": max_empty_chunks,
@@ -72,9 +81,10 @@ def main(
     if cfg.input is None:
         raise click.ClickException("No input PDF provided. Pass INPUT_PDF or set 'input' in docdown.yaml.")
 
-    click.echo(f"DocDown v{_version()}")
-    click.echo(f"Input:   {cfg.input}")
-    click.echo(f"Workdir: {cfg.workdir}")
+    logger = configure_logging(cfg.workdir, cfg.log_level)
+    logger.info("DocDown v%s", _version())
+    logger.info("Input:   %s", cfg.input)
+    logger.info("Workdir: %s", cfg.workdir)
 
 
 def _version():

--- a/docdown/config.py
+++ b/docdown/config.py
@@ -11,6 +11,7 @@ import yaml
 
 
 _VALID_EXTRACTORS = {"grobid", "pdfminer"}
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "WARN"}
 
 
 class ConfigError(ValueError):
@@ -39,6 +40,7 @@ class Config:
     table_extraction: bool = True
     llm_cleanup: bool = False
     llm_model: str | None = None
+    log_level: str = "INFO"
     validation: ValidationConfig = field(default_factory=ValidationConfig)
 
 
@@ -73,6 +75,7 @@ def _default_data() -> dict[str, Any]:
         "table_extraction": defaults.table_extraction,
         "llm_cleanup": defaults.llm_cleanup,
         "llm_model": defaults.llm_model,
+        "log_level": defaults.log_level,
         "validation": {
             "min_output_ratio": defaults.validation.min_output_ratio,
             "max_empty_chunks": defaults.validation.max_empty_chunks,
@@ -159,6 +162,7 @@ def _build_and_validate(data: dict[str, Any]) -> Config:
             table_extraction=_require_bool(data["table_extraction"], "table_extraction"),
             llm_cleanup=_require_bool(data["llm_cleanup"], "llm_cleanup"),
             llm_model=str(data["llm_model"]) if data["llm_model"] is not None else None,
+            log_level=str(data["log_level"]).upper(),
             validation=validation_cfg,
         )
     except ConfigError:
@@ -193,6 +197,8 @@ def _validate_semantics(cfg: Config) -> None:
         raise ConfigError(f"extractor must be one of: {sorted(_VALID_EXTRACTORS)}")
     if cfg.fallback_extractor not in _VALID_EXTRACTORS:
         raise ConfigError(f"fallback_extractor must be one of: {sorted(_VALID_EXTRACTORS)}")
+    if cfg.log_level not in _VALID_LOG_LEVELS:
+        raise ConfigError(f"log_level must be one of: {sorted(_VALID_LOG_LEVELS)}")
     if not math.isfinite(cfg.validation.min_output_ratio):
         raise ConfigError("validation.min_output_ratio must be a finite number.")
     if cfg.validation.min_output_ratio <= 0:

--- a/docdown/utils/logging.py
+++ b/docdown/utils/logging.py
@@ -41,6 +41,8 @@ def configure_logging(workdir: Path, level: str = "INFO") -> logging.Logger:
     log_file = log_dir / "run.log"
 
     logger = logging.getLogger(LOGGER_NAME)
+    for handler in logger.handlers:
+        handler.close()
     logger.handlers.clear()
     logger.propagate = False
     logger.setLevel(_normalize_level(level))

--- a/docdown/utils/logging.py
+++ b/docdown/utils/logging.py
@@ -1,1 +1,112 @@
-"""Logging setup (placeholder)."""
+"""Central logging setup for DocDown."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+
+LOGGER_NAME = "docdown"
+LOG_FORMAT = "%(asctime)s %(levelname)-5s [%(chunk)s] %(message)s"
+LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+class _ChunkFieldFilter(logging.Filter):
+	"""Ensure all log records include a chunk field for formatter stability."""
+
+	def filter(self, record: logging.LogRecord) -> bool:
+		if not hasattr(record, "chunk"):
+			record.chunk = "-"
+		return True
+
+
+class ChunkAdapter(logging.LoggerAdapter):
+	"""Logger adapter that injects a normalized chunk identifier."""
+
+	def process(self, msg: str, kwargs: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+		extra = kwargs.get("extra", {})
+		chunk = extra.get("chunk", self.extra.get("chunk"))
+		extra["chunk"] = _normalize_chunk(chunk)
+		kwargs["extra"] = extra
+		return msg, kwargs
+
+
+def configure_logging(workdir: Path, level: str = "INFO") -> logging.Logger:
+	"""Configure the central logger to write to stderr and workdir/run.log."""
+
+	log_dir = Path(workdir)
+	log_dir.mkdir(parents=True, exist_ok=True)
+	log_file = log_dir / "run.log"
+
+	logger = logging.getLogger(LOGGER_NAME)
+	logger.handlers.clear()
+	logger.propagate = False
+	logger.setLevel(_normalize_level(level))
+
+	formatter = logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
+	chunk_filter = _ChunkFieldFilter()
+
+	stream_handler = logging.StreamHandler(sys.stderr)
+	stream_handler.setFormatter(formatter)
+	stream_handler.addFilter(chunk_filter)
+
+	file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+	file_handler.setFormatter(formatter)
+	file_handler.addFilter(chunk_filter)
+
+	logger.addHandler(stream_handler)
+	logger.addHandler(file_handler)
+
+	logger.debug("Configured logging level=%s run_log=%s", logger.level, log_file)
+	return logger
+
+
+def get_logger() -> logging.Logger:
+	"""Return the central DocDown logger."""
+
+	return logging.getLogger(LOGGER_NAME)
+
+
+def get_chunk_logger(chunk_number: int | str) -> ChunkAdapter:
+	"""Return a chunk-aware logger adapter for chunk-scoped log messages."""
+
+	return ChunkAdapter(get_logger(), {"chunk": _normalize_chunk(chunk_number)})
+
+
+def log_tool_command(command: list[str] | tuple[str, ...] | str, chunk_number: int | str | None = None) -> None:
+	"""Emit a standardized DEBUG message for subprocess command execution."""
+
+	logger: logging.Logger | ChunkAdapter
+	logger = get_logger() if chunk_number is None else get_chunk_logger(chunk_number)
+	if isinstance(command, (list, tuple)):
+		command_text = " ".join(str(part) for part in command)
+	else:
+		command_text = str(command)
+	logger.debug("tool command: %s", command_text)
+
+
+def log_intermediate_path(path: Path, label: str | None = None, chunk_number: int | str | None = None) -> None:
+	"""Emit a standardized DEBUG message for intermediate artifact paths."""
+
+	logger: logging.Logger | ChunkAdapter
+	logger = get_logger() if chunk_number is None else get_chunk_logger(chunk_number)
+	prefix = f"{label}: " if label else ""
+	logger.debug("%s%s", prefix, path)
+
+
+def _normalize_level(level: str) -> int:
+	upper = str(level).upper()
+	if upper == "WARN":
+		upper = "WARNING"
+	return getattr(logging, upper, logging.INFO)
+
+
+def _normalize_chunk(chunk: int | str | None) -> str:
+	if chunk is None:
+		return "-"
+	if isinstance(chunk, int):
+		return f"chunk-{chunk:04d}"
+	chunk_text = str(chunk)
+	return chunk_text if chunk_text.startswith("chunk-") else f"chunk-{chunk_text}"

--- a/docdown/utils/logging.py
+++ b/docdown/utils/logging.py
@@ -102,7 +102,10 @@ def _normalize_level(level: str) -> int:
     upper = str(level).upper()
     if upper == "WARN":
         upper = "WARNING"
-    return getattr(logging, upper, logging.INFO)
+    numeric_level = getattr(logging, upper, None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f"Unknown log level: {level}")
+    return numeric_level
 
 
 def _normalize_chunk(chunk: int | str | None) -> str:

--- a/docdown/utils/logging.py
+++ b/docdown/utils/logging.py
@@ -14,99 +14,99 @@ LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 
 class _ChunkFieldFilter(logging.Filter):
-	"""Ensure all log records include a chunk field for formatter stability."""
+    """Ensure all log records include a chunk field for formatter stability."""
 
-	def filter(self, record: logging.LogRecord) -> bool:
-		if not hasattr(record, "chunk"):
-			record.chunk = "-"
-		return True
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "chunk"):
+            record.chunk = "-"
+        return True
 
 
 class ChunkAdapter(logging.LoggerAdapter):
-	"""Logger adapter that injects a normalized chunk identifier."""
+    """Logger adapter that injects a normalized chunk identifier."""
 
-	def process(self, msg: str, kwargs: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-		extra = kwargs.get("extra", {})
-		chunk = extra.get("chunk", self.extra.get("chunk"))
-		extra["chunk"] = _normalize_chunk(chunk)
-		kwargs["extra"] = extra
-		return msg, kwargs
+    def process(self, msg: str, kwargs: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        extra = kwargs.get("extra", {})
+        chunk = extra.get("chunk", self.extra.get("chunk"))
+        extra["chunk"] = _normalize_chunk(chunk)
+        kwargs["extra"] = extra
+        return msg, kwargs
 
 
 def configure_logging(workdir: Path, level: str = "INFO") -> logging.Logger:
-	"""Configure the central logger to write to stderr and workdir/run.log."""
+    """Configure the central logger to write to stderr and workdir/run.log."""
 
-	log_dir = Path(workdir)
-	log_dir.mkdir(parents=True, exist_ok=True)
-	log_file = log_dir / "run.log"
+    log_dir = Path(workdir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "run.log"
 
-	logger = logging.getLogger(LOGGER_NAME)
-	logger.handlers.clear()
-	logger.propagate = False
-	logger.setLevel(_normalize_level(level))
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(_normalize_level(level))
 
-	formatter = logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
-	chunk_filter = _ChunkFieldFilter()
+    formatter = logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
+    chunk_filter = _ChunkFieldFilter()
 
-	stream_handler = logging.StreamHandler(sys.stderr)
-	stream_handler.setFormatter(formatter)
-	stream_handler.addFilter(chunk_filter)
+    stream_handler = logging.StreamHandler(sys.stderr)
+    stream_handler.setFormatter(formatter)
+    stream_handler.addFilter(chunk_filter)
 
-	file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
-	file_handler.setFormatter(formatter)
-	file_handler.addFilter(chunk_filter)
+    file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    file_handler.addFilter(chunk_filter)
 
-	logger.addHandler(stream_handler)
-	logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+    logger.addHandler(file_handler)
 
-	logger.debug("Configured logging level=%s run_log=%s", logger.level, log_file)
-	return logger
+    logger.debug("Configured logging level=%s run_log=%s", logger.level, log_file)
+    return logger
 
 
 def get_logger() -> logging.Logger:
-	"""Return the central DocDown logger."""
+    """Return the central DocDown logger."""
 
-	return logging.getLogger(LOGGER_NAME)
+    return logging.getLogger(LOGGER_NAME)
 
 
 def get_chunk_logger(chunk_number: int | str) -> ChunkAdapter:
-	"""Return a chunk-aware logger adapter for chunk-scoped log messages."""
+    """Return a chunk-aware logger adapter for chunk-scoped log messages."""
 
-	return ChunkAdapter(get_logger(), {"chunk": _normalize_chunk(chunk_number)})
+    return ChunkAdapter(get_logger(), {"chunk": _normalize_chunk(chunk_number)})
 
 
 def log_tool_command(command: list[str] | tuple[str, ...] | str, chunk_number: int | str | None = None) -> None:
-	"""Emit a standardized DEBUG message for subprocess command execution."""
+    """Emit a standardized DEBUG message for subprocess command execution."""
 
-	logger: logging.Logger | ChunkAdapter
-	logger = get_logger() if chunk_number is None else get_chunk_logger(chunk_number)
-	if isinstance(command, (list, tuple)):
-		command_text = " ".join(str(part) for part in command)
-	else:
-		command_text = str(command)
-	logger.debug("tool command: %s", command_text)
+    logger: logging.Logger | ChunkAdapter
+    logger = get_logger() if chunk_number is None else get_chunk_logger(chunk_number)
+    if isinstance(command, (list, tuple)):
+        command_text = " ".join(str(part) for part in command)
+    else:
+        command_text = str(command)
+    logger.debug("tool command: %s", command_text)
 
 
 def log_intermediate_path(path: Path, label: str | None = None, chunk_number: int | str | None = None) -> None:
-	"""Emit a standardized DEBUG message for intermediate artifact paths."""
+    """Emit a standardized DEBUG message for intermediate artifact paths."""
 
-	logger: logging.Logger | ChunkAdapter
-	logger = get_logger() if chunk_number is None else get_chunk_logger(chunk_number)
-	prefix = f"{label}: " if label else ""
-	logger.debug("%s%s", prefix, path)
+    logger: logging.Logger | ChunkAdapter
+    logger = get_logger() if chunk_number is None else get_chunk_logger(chunk_number)
+    prefix = f"{label}: " if label else ""
+    logger.debug("%s%s", prefix, path)
 
 
 def _normalize_level(level: str) -> int:
-	upper = str(level).upper()
-	if upper == "WARN":
-		upper = "WARNING"
-	return getattr(logging, upper, logging.INFO)
+    upper = str(level).upper()
+    if upper == "WARN":
+        upper = "WARNING"
+    return getattr(logging, upper, logging.INFO)
 
 
 def _normalize_chunk(chunk: int | str | None) -> str:
-	if chunk is None:
-		return "-"
-	if isinstance(chunk, int):
-		return f"chunk-{chunk:04d}"
-	chunk_text = str(chunk)
-	return chunk_text if chunk_text.startswith("chunk-") else f"chunk-{chunk_text}"
+    if chunk is None:
+        return "-"
+    if isinstance(chunk, int):
+        return f"chunk-{chunk:04d}"
+    chunk_text = str(chunk)
+    return chunk_text if chunk_text.startswith("chunk-") else f"chunk-{chunk_text}"

--- a/docs/plan/task-1.3-logging.md
+++ b/docs/plan/task-1.3-logging.md
@@ -10,12 +10,12 @@ Set up structured logging with configurable levels, file output, and per-chunk c
 
 ## Acceptance Criteria
 
-- [ ] All pipeline output is logged via a central logger (no bare `print` statements).
-- [ ] Log output writes to both stderr and `workdir/run.log`.
-- [ ] Log level is configurable (default: `INFO`).
-- [ ] Each log entry includes: timestamp, level, and chunk identifier (where applicable).
-- [ ] `DEBUG` level includes tool command lines and intermediate file paths.
-- [ ] Unit tests verify log format and file output.
+- [x] All pipeline output is logged via a central logger (no bare `print` statements).
+- [x] Log output writes to both stderr and `workdir/run.log`.
+- [x] Log level is configurable (default: `INFO`).
+- [x] Each log entry includes: timestamp, level, and chunk identifier (where applicable).
+- [x] `DEBUG` level includes tool command lines and intermediate file paths.
+- [x] Unit tests verify log format and file output.
 
 ## Implementation Notes
 

--- a/docs/plan/task-1.3-logging.md
+++ b/docs/plan/task-1.3-logging.md
@@ -32,6 +32,75 @@ Set up structured logging with configurable levels, file output, and per-chunk c
 - Create a `ChunkAdapter` or use `LoggerAdapter` to inject chunk ID into log records.
 - File handler is added once `workdir` is created (Task 1.4).
 
+### Artifact Class Diagram
+
+```mermaid
+classDiagram
+	class Config {
+		+Path workdir
+		+str log_level
+	}
+
+	class CliMain {
+		<<module: docdown/cli.py>>
+		+main(..., log_level) None
+	}
+
+	class LoggingModule {
+		<<module: docdown/utils/logging.py>>
+		+configure_logging(workdir, level) Logger
+		+get_logger() Logger
+		+get_chunk_logger(chunk_number) ChunkAdapter
+		+log_tool_command(command, chunk_number) None
+		+log_intermediate_path(path, label, chunk_number) None
+	}
+
+	class ChunkAdapter {
+		<<LoggerAdapter>>
+		+process(msg, kwargs) tuple
+	}
+
+	class RunLog {
+		<<file: workdir/run.log>>
+		+UTF-8 log sink
+	}
+
+	class StderrSink {
+		<<stream: stderr>>
+		+console log sink
+	}
+
+	class DocdownYaml {
+		<<file: docdown.yaml>>
+		+log_level: INFO
+	}
+
+	class TestLogging {
+		<<tests/test_logging.py>>
+		+format/file/chunk/debug coverage
+	}
+
+	class TestCli {
+		<<tests/test_cli.py>>
+		+CLI log-level and output coverage
+	}
+
+	class TestConfig {
+		<<tests/test_config.py>>
+		+log_level config validation coverage
+	}
+
+	CliMain ..> Config : loads
+	CliMain ..> LoggingModule : calls configure_logging
+	Config ..> DocdownYaml : defaults/overrides
+	LoggingModule --> ChunkAdapter : creates
+	LoggingModule --> RunLog : writes
+	LoggingModule --> StderrSink : writes
+	TestLogging ..> LoggingModule : verifies behavior
+	TestCli ..> CliMain : verifies integration
+	TestConfig ..> Config : verifies log_level rules
+```
+
 ## References
 
 - [technical-design.md §9.2 — Logging](../technical-design.md)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,9 +12,9 @@ def test_cli_shows_version(tmp_path):
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
     assert result.exit_code == 0
-    assert f"DocDown v{__version__}" in result.output
-    assert "Input:" in result.output
-    assert "Workdir:" in result.output
+    assert f"DocDown v{__version__}" in result.stderr
+    assert "Input:" in result.stderr
+    assert "Workdir:" in result.stderr
 
     log_file = tmp_path / "out" / "run.log"
     assert log_file.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,11 @@ def test_cli_shows_version(tmp_path):
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
     assert result.exit_code == 0
+    assert f"DocDown v{__version__}" in result.output
+    assert "Input:" in result.output
+    assert "Workdir:" in result.output
+
+    # Startup summaries are also logged through stderr.
     assert f"DocDown v{__version__}" in result.stderr
     assert "Input:" in result.stderr
     assert "Workdir:" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,11 @@ def test_cli_shows_version(tmp_path):
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
     assert result.exit_code == 0
     assert f"DocDown v{__version__}" in result.output
+    assert "Input:" in result.output
+    assert "Workdir:" in result.output
+
+    log_file = tmp_path / "out" / "run.log"
+    assert log_file.exists()
 
 
 def test_cli_rejects_file_path_for_workdir(tmp_path):
@@ -28,3 +33,13 @@ def test_cli_rejects_file_path_for_workdir(tmp_path):
     assert result.exit_code != 0
     assert "--workdir" in result.output
     assert "Invalid value" in result.output
+
+
+def test_cli_accepts_log_level_flag(tmp_path):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--log-level", "debug"])
+
+    assert result.exit_code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_config_defaults_without_file():
     assert cfg.fallback_extractor == "pdfminer"
     assert cfg.table_extraction is True
     assert cfg.llm_cleanup is False
+    assert cfg.log_level == "INFO"
     assert cfg.validation.min_output_ratio == 0.01
     assert cfg.validation.max_empty_chunks == 0
 
@@ -43,6 +44,7 @@ def test_config_loads_from_yaml(tmp_path):
                 "table_extraction: false",
                 "llm_cleanup: true",
                 "llm_model: gpt-4o-mini",
+                "log_level: DEBUG",
                 "validation:",
                 "  min_output_ratio: 0.02",
                 "  max_empty_chunks: 1",
@@ -63,6 +65,7 @@ def test_config_loads_from_yaml(tmp_path):
     assert cfg.table_extraction is False
     assert cfg.llm_cleanup is True
     assert cfg.llm_model == "gpt-4o-mini"
+    assert cfg.log_level == "DEBUG"
     assert cfg.validation.min_output_ratio == 0.02
     assert cfg.validation.max_empty_chunks == 1
 
@@ -75,6 +78,7 @@ def test_cli_overrides_config_values(tmp_path):
                 "workdir: ./from-file",
                 "chunk_size: 100",
                 "parallel_workers: 8",
+                "log_level: ERROR",
                 "validation:",
                 "  min_output_ratio: 0.05",
             ]
@@ -88,6 +92,7 @@ def test_cli_overrides_config_values(tmp_path):
             "workdir": "./from-cli",
             "chunk_size": 20,
             "parallel_workers": 3,
+            "log_level": "debug",
             "validation": {
                 "min_output_ratio": 0.1,
             },
@@ -97,6 +102,7 @@ def test_cli_overrides_config_values(tmp_path):
     assert str(cfg.workdir) == "from-cli"
     assert cfg.chunk_size == 20
     assert cfg.parallel_workers == 3
+    assert cfg.log_level == "DEBUG"
     assert cfg.validation.min_output_ratio == 0.1
 
 
@@ -106,6 +112,9 @@ def test_invalid_config_raises_clear_error():
 
     with pytest.raises(ConfigError, match="extractor must be one of"):
         load_config(cli_overrides={"extractor": "invalid"})
+
+    with pytest.raises(ConfigError, match="log_level must be one of"):
+        load_config(cli_overrides={"log_level": "VERBOSE"})
 
 
 def test_string_boolean_values_are_rejected(tmp_path):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,60 @@
+"""Tests for DocDown logging framework."""
+
+import re
+from pathlib import Path
+
+from docdown.utils.logging import (
+    configure_logging,
+    get_chunk_logger,
+    get_logger,
+    log_intermediate_path,
+    log_tool_command,
+)
+
+
+def test_logging_writes_to_run_log_and_includes_chunk(tmp_path):
+    logger = configure_logging(tmp_path, "INFO")
+    logger.info("pipeline started")
+
+    chunk_logger = get_chunk_logger(7)
+    chunk_logger.info("processing chunk")
+
+    content = (tmp_path / "run.log").read_text(encoding="utf-8")
+
+    assert "pipeline started" in content
+    assert "processing chunk" in content
+    assert "[chunk-0007]" in content
+
+
+def test_logging_format_includes_timestamp_level_and_chunk(tmp_path):
+    logger = configure_logging(tmp_path, "INFO")
+    logger.info("format check")
+
+    first_line = (tmp_path / "run.log").read_text(encoding="utf-8").splitlines()[0]
+
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} INFO\s+\[[^\]]+\] .+", first_line)
+
+
+def test_debug_level_emits_debug_messages(tmp_path):
+    logger = configure_logging(tmp_path, "DEBUG")
+    logger.debug("debug detail")
+
+    content = (tmp_path / "run.log").read_text(encoding="utf-8")
+    assert "debug detail" in content
+
+
+def test_debug_helpers_log_command_and_path(tmp_path):
+    configure_logging(tmp_path, "DEBUG")
+
+    log_tool_command(["qpdf", "input.pdf", "--check"], chunk_number=12)
+    log_intermediate_path(Path("workdir/extracted/chunk-0012.xml"), label="intermediate", chunk_number=12)
+
+    content = (tmp_path / "run.log").read_text(encoding="utf-8")
+    assert "tool command: qpdf input.pdf --check" in content
+    assert "intermediate: workdir\\extracted\\chunk-0012.xml" in content or "intermediate: workdir/extracted/chunk-0012.xml" in content
+    assert "[chunk-0012]" in content
+
+
+def test_get_logger_returns_central_logger(tmp_path):
+    configured = configure_logging(tmp_path, "INFO")
+    assert get_logger() is configured

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,8 @@
 import re
 from pathlib import Path
 
+import pytest
+
 from docdown.utils.logging import (
     configure_logging,
     get_chunk_logger,
@@ -58,3 +60,8 @@ def test_debug_helpers_log_command_and_path(tmp_path):
 def test_get_logger_returns_central_logger(tmp_path):
     configured = configure_logging(tmp_path, "INFO")
     assert get_logger() is configured
+
+
+def test_invalid_log_level_raises_error(tmp_path):
+    with pytest.raises(ValueError, match="Unknown log level"):
+        configure_logging(tmp_path, "VERBOSE")


### PR DESCRIPTION
## Summary
- implement central logging module in docdown/utils/logging.py
- add dual log sinks: stderr and workdir/run.log
- add chunk-aware logging via ChunkAdapter
- add DEBUG helpers for tool commands and intermediate paths
- add configurable log_level in config and CLI (--log-level)
- route CLI startup output through logger instead of bare prints
- update Task 1.3 plan doc and add Mermaid artifact diagram

## Validation
- python -m pytest -q
- result: 24 passed
