### PR TITLE
Task 1.4: Working directory management

### DIFF
--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -4,6 +4,7 @@ import click
 
 from docdown.config import ConfigError, load_config
 from docdown.utils.logging import configure_logging
+from docdown.workdir import WorkDir, WorkDirError
 
 
 @click.command()
@@ -81,6 +82,13 @@ def main(
     if cfg.input is None:
         raise click.ClickException("No input PDF provided. Pass INPUT_PDF or set 'input' in docdown.yaml.")
 
+    try:
+        workdir = WorkDir(cfg.workdir)
+        workdir.ensure_structure()
+        staged_input = workdir.stage_input(cfg.input)
+    except WorkDirError as exc:
+        raise click.ClickException(str(exc)) from exc
+
     logger = configure_logging(cfg.workdir, cfg.log_level)
     version_text = f"DocDown v{_version()}"
     input_text = f"Input:   {cfg.input}"
@@ -94,6 +102,7 @@ def main(
     logger.info(version_text)
     logger.info(input_text)
     logger.info(workdir_text)
+    logger.debug("Staged input at %s", staged_input)
 
 
 def _version():

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -83,9 +83,9 @@ def main(
         raise click.ClickException("No input PDF provided. Pass INPUT_PDF or set 'input' in docdown.yaml.")
 
     try:
-        workdir = WorkDir(cfg.workdir)
-        workdir.ensure_structure()
-        staged_input = workdir.stage_input(cfg.input)
+        work_dir = WorkDir(cfg.workdir)
+        work_dir.ensure_structure()
+        staged_input = work_dir.stage_input(cfg.input)
     except WorkDirError as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -53,7 +53,7 @@ class WorkDir:
             raise WorkDirError(f"failed to create workdir structure at {self.base}: {exc}") from exc
 
     def stage_input(self, source_pdf: Path) -> Path:
-        """Place the input PDF in workdir/input as a symlink or copied file."""
+        """Stage the input PDF at workdir/input/source.pdf via symlink or copy."""
 
         source = Path(source_pdf)
         if not source.exists() or not source.is_file():

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -72,6 +72,8 @@ class WorkDir:
                     return target
             except OSError:
                 pass
+            if _copied_input_matches(source, target):
+                return target
             try:
                 target.unlink()
             except OSError as exc:
@@ -138,3 +140,38 @@ class WorkDir:
 
     def final_markdown(self) -> Path:
         return self.base / "final.md"
+
+
+def _copied_input_matches(source: Path, target: Path) -> bool:
+    """Return True when staged target looks like an up-to-date copied source."""
+
+    try:
+        source_stat = source.stat()
+        target_stat = target.stat()
+    except OSError:
+        return False
+
+    if source_stat.st_size != target_stat.st_size:
+        return False
+
+    # copy2 preserves timestamps; allow 1-second tolerance for filesystem precision.
+    if abs(source_stat.st_mtime - target_stat.st_mtime) > 1.0:
+        return False
+
+    return _files_equal(source, target)
+
+
+def _files_equal(left: Path, right: Path) -> bool:
+    """Compare file bytes in chunks to avoid loading large PDFs fully into memory."""
+
+    try:
+        with left.open("rb") as left_handle, right.open("rb") as right_handle:
+            while True:
+                left_block = left_handle.read(1024 * 1024)
+                right_block = right_handle.read(1024 * 1024)
+                if left_block != right_block:
+                    return False
+                if not left_block:
+                    return True
+    except OSError:
+        return False

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -45,9 +45,12 @@ class WorkDir:
         if self.base.exists() and not self.base.is_dir():
             raise WorkDirError(f"workdir must be a directory: {self.base}")
 
-        self.base.mkdir(parents=True, exist_ok=True)
-        for name in _WORKDIR_SUBDIRS:
-            (self.base / name).mkdir(parents=True, exist_ok=True)
+        try:
+            self.base.mkdir(parents=True, exist_ok=True)
+            for name in _WORKDIR_SUBDIRS:
+                (self.base / name).mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise WorkDirError(f"failed to create workdir structure at {self.base}: {exc}") from exc
 
     def stage_input(self, source_pdf: Path) -> Path:
         """Place the input PDF in workdir/input as a symlink or copied file."""

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -59,6 +59,9 @@ class WorkDir:
         if not source.exists() or not source.is_file():
             raise WorkDirError(f"input file not found: {source}")
 
+        # Allow direct stage_input() calls without requiring ensure_structure() first.
+        self.ensure_structure()
+
         target = self.input_dir / "source.pdf"
 
         if target.exists() or target.is_symlink():

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
 
 _WORKDIR_SUBDIRS = ("input", "chunks", "extracted", "markdown", "tables")
+_INPUT_MANIFEST_NAME = "source.manifest.json"
 
 
 class WorkDirError(ValueError):
@@ -63,6 +65,7 @@ class WorkDir:
         self.ensure_structure()
 
         target = self.input_dir / "source.pdf"
+        manifest_path = self.input_dir / _INPUT_MANIFEST_NAME
 
         if target.exists() or target.is_symlink():
             if target.is_dir():
@@ -72,7 +75,7 @@ class WorkDir:
                     return target
             except OSError:
                 pass
-            if _copied_input_matches(source, target):
+            if _copy_manifest_matches(source, target, manifest_path):
                 return target
             try:
                 target.unlink()
@@ -81,9 +84,11 @@ class WorkDir:
 
         try:
             target.symlink_to(source.resolve())
+            _delete_manifest_if_exists(manifest_path)
         except OSError:
             try:
                 shutil.copy2(source, target)
+                _write_copy_manifest(manifest_path, source, target)
             except OSError as exc:
                 raise WorkDirError(f"failed to stage input into {target}: {exc}") from exc
 
@@ -142,39 +147,80 @@ class WorkDir:
         return self.base / "final.md"
 
 
-def _copied_input_matches(source: Path, target: Path) -> bool:
-    """Return True when staged target looks like an up-to-date copied source."""
+def _copy_manifest_matches(source: Path, target: Path, manifest_path: Path) -> bool:
+    """Return True when cached metadata says the copied input is up-to-date."""
+
+    if not target.exists() or target.is_symlink():
+        return False
+
+    manifest = _read_manifest(manifest_path)
+    if manifest is None:
+        return False
+
+    expected_source = manifest.get("source")
+    expected_target = manifest.get("target")
+    if not isinstance(expected_source, dict) or not isinstance(expected_target, dict):
+        return False
+
+    current_source = _source_fingerprint(source)
+    current_target = _target_fingerprint(target)
+    return current_source == expected_source and current_target == expected_target
+
+
+def _write_copy_manifest(manifest_path: Path, source: Path, target: Path) -> None:
+    """Write lightweight metadata used to skip redundant copy fallback operations."""
+
+    manifest = {
+        "source": _source_fingerprint(source),
+        "target": _target_fingerprint(target),
+    }
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+
+def _read_manifest(manifest_path: Path) -> dict[str, object] | None:
+    """Read copy manifest data and return None when unavailable or invalid."""
 
     try:
-        source_stat = source.stat()
-        target_stat = target.stat()
-    except OSError:
-        return False
-
-    if source_stat.st_size != target_stat.st_size:
-        return False
-
-    # copy2 preserves timestamps; allow 1-second tolerance for filesystem precision.
-    if abs(source_stat.st_mtime - target_stat.st_mtime) > 1.0:
-        return False
-
-    return _files_equal(source, target)
+        raw = manifest_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
-def _files_equal(left: Path, right: Path) -> bool:
-    """Compare file bytes in chunks to avoid loading large PDFs fully into memory."""
+def _delete_manifest_if_exists(manifest_path: Path) -> None:
+    """Best-effort cleanup for stale copy manifests after symlink staging."""
 
     try:
-        with left.open("rb") as left_handle, right.open("rb") as right_handle:
-            while True:
-                left_block = left_handle.read(1024 * 1024)
-                right_block = right_handle.read(1024 * 1024)
-                if left_block != right_block:
-                    return False
-                if not left_block:
-                    return True
+        if manifest_path.exists():
+            manifest_path.unlink()
     except OSError:
-        return False
+        pass
+
+
+def _source_fingerprint(path: Path) -> dict[str, object]:
+    """Return source metadata used to detect whether staging input changed."""
+
+    stat = path.stat()
+    try:
+        resolved = str(path.resolve())
+    except OSError:
+        resolved = str(path.absolute())
+    return {
+        "path": resolved,
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _target_fingerprint(path: Path) -> dict[str, object]:
+    """Return staged target metadata for copy-manifest validation."""
+
+    stat = path.stat()
+    return {
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
 
 
 def _normalize_extension(ext: str) -> str:

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -1,0 +1,128 @@
+"""Working directory management for DocDown artifacts."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+_WORKDIR_SUBDIRS = ("input", "chunks", "extracted", "markdown", "tables")
+
+
+class WorkDirError(ValueError):
+    """Raised when workdir initialization or staging fails."""
+
+
+class WorkDir:
+    """Helper for creating and addressing run artifacts under a workdir."""
+
+    def __init__(self, base: Path):
+        self.base = Path(base)
+
+    @property
+    def input_dir(self) -> Path:
+        return self.base / "input"
+
+    @property
+    def chunks_dir(self) -> Path:
+        return self.base / "chunks"
+
+    @property
+    def extracted_dir(self) -> Path:
+        return self.base / "extracted"
+
+    @property
+    def markdown_dir(self) -> Path:
+        return self.base / "markdown"
+
+    @property
+    def tables_dir(self) -> Path:
+        return self.base / "tables"
+
+    def ensure_structure(self) -> None:
+        """Create the base workdir and required subdirectories if missing."""
+
+        if self.base.exists() and not self.base.is_dir():
+            raise WorkDirError(f"workdir must be a directory: {self.base}")
+
+        self.base.mkdir(parents=True, exist_ok=True)
+        for name in _WORKDIR_SUBDIRS:
+            (self.base / name).mkdir(parents=True, exist_ok=True)
+
+    def stage_input(self, source_pdf: Path) -> Path:
+        """Place the input PDF in workdir/input as a symlink or copied file."""
+
+        source = Path(source_pdf)
+        if not source.exists() or not source.is_file():
+            raise WorkDirError(f"input file not found: {source}")
+
+        target = self.input_dir / "source.pdf"
+
+        if target.exists() or target.is_symlink():
+            if target.is_dir():
+                raise WorkDirError(f"staged input path is a directory: {target}")
+            try:
+                if target.resolve() == source.resolve():
+                    return target
+            except OSError:
+                pass
+            target.unlink()
+
+        try:
+            target.symlink_to(source.resolve())
+        except OSError:
+            shutil.copy2(source, target)
+
+        return target
+
+    def artifact_path(
+        self,
+        artifact_type: str,
+        chunk_number: int,
+        *,
+        ext: str | None = None,
+        table_number: int | None = None,
+    ) -> Path:
+        """Return artifact path by type and chunk number."""
+
+        if chunk_number < 1:
+            raise WorkDirError("chunk_number must be >= 1")
+
+        chunk_token = f"chunk-{chunk_number:04d}"
+
+        if artifact_type == "chunks":
+            return self.chunks_dir / f"{chunk_token}.pdf"
+
+        if artifact_type == "extracted":
+            extension = ext or "xml"
+            return self.extracted_dir / f"{chunk_token}.{extension}"
+
+        if artifact_type == "markdown":
+            extension = ext or "md"
+            return self.markdown_dir / f"{chunk_token}.{extension}"
+
+        if artifact_type == "tables":
+            if table_number is None or table_number < 1:
+                raise WorkDirError("tables artifacts require table_number >= 1")
+            extension = ext or "md"
+            return self.tables_dir / f"{chunk_token}-table-{table_number:03d}.{extension}"
+
+        raise WorkDirError(f"unknown artifact_type: {artifact_type}")
+
+    def chunk_pdf(self, chunk_number: int) -> Path:
+        return self.artifact_path("chunks", chunk_number)
+
+    def extracted(self, chunk_number: int, ext: str = "xml") -> Path:
+        return self.artifact_path("extracted", chunk_number, ext=ext)
+
+    def markdown(self, chunk_number: int, ext: str = "md") -> Path:
+        return self.artifact_path("markdown", chunk_number, ext=ext)
+
+    def table_markdown(self, chunk_number: int, table_number: int, ext: str = "md") -> Path:
+        return self.artifact_path("tables", chunk_number, ext=ext, table_number=table_number)
+
+    def merged_markdown(self) -> Path:
+        return self.base / "merged.md"
+
+    def final_markdown(self) -> Path:
+        return self.base / "final.md"

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -69,12 +69,18 @@ class WorkDir:
                     return target
             except OSError:
                 pass
-            target.unlink()
+            try:
+                target.unlink()
+            except OSError as exc:
+                raise WorkDirError(f"failed to replace staged input at {target}: {exc}") from exc
 
         try:
             target.symlink_to(source.resolve())
         except OSError:
-            shutil.copy2(source, target)
+            try:
+                shutil.copy2(source, target)
+            except OSError as exc:
+                raise WorkDirError(f"failed to stage input into {target}: {exc}") from exc
 
         return target
 

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -108,17 +108,17 @@ class WorkDir:
             return self.chunks_dir / f"{chunk_token}.pdf"
 
         if artifact_type == "extracted":
-            extension = ext or "xml"
+            extension = _normalize_extension(ext or "xml")
             return self.extracted_dir / f"{chunk_token}.{extension}"
 
         if artifact_type == "markdown":
-            extension = ext or "md"
+            extension = _normalize_extension(ext or "md")
             return self.markdown_dir / f"{chunk_token}.{extension}"
 
         if artifact_type == "tables":
             if table_number is None or table_number < 1:
                 raise WorkDirError("tables artifacts require table_number >= 1")
-            extension = ext or "md"
+            extension = _normalize_extension(ext or "md")
             return self.tables_dir / f"{chunk_token}-table-{table_number:03d}.{extension}"
 
         raise WorkDirError(f"unknown artifact_type: {artifact_type}")
@@ -175,3 +175,14 @@ def _files_equal(left: Path, right: Path) -> bool:
                     return True
     except OSError:
         return False
+
+
+def _normalize_extension(ext: str) -> str:
+    """Normalize and validate extension tokens used in generated filenames."""
+
+    normalized = str(ext).lstrip(".")
+    if not normalized:
+        raise WorkDirError("ext must not be empty.")
+    if "/" in normalized or "\\" in normalized or ".." in normalized:
+        raise WorkDirError("ext must not contain path separators or '..'.")
+    return normalized

--- a/docs/plan/task-1.4-workdir-management.md
+++ b/docs/plan/task-1.4-workdir-management.md
@@ -10,12 +10,17 @@ Create and manage the working directory structure where all intermediate and out
 
 ## Acceptance Criteria
 
-- [ ] Working directory is created at the configured `workdir` path.
-- [ ] Subdirectories are created: `input/`, `chunks/`, `extracted/`, `markdown/`, `tables/`.
-- [ ] If `workdir` already exists, pipeline resumes without deleting previous files (allows reprocessing).
-- [ ] Input PDF is copied or symlinked into `input/`.
-- [ ] A helper function returns the path for any artifact given its type and chunk number.
-- [ ] Unit tests verify directory creation and path generation.
+- [x] Working directory is created at the configured `workdir` path.
+- [x] Subdirectories are created: `input/`, `chunks/`, `extracted/`, `markdown/`, `tables/`.
+- [x] If `workdir` already exists, pipeline resumes without deleting previous files (allows reprocessing).
+- [x] Input PDF is copied or symlinked into `input/`.
+- [x] A helper function returns the path for any artifact given its type and chunk number.
+- [x] Unit tests verify directory creation and path generation.
+
+Implemented in:
+- `docdown/workdir.py`
+- `docdown/cli.py`
+- `tests/test_workdir.py`
 
 ## Implementation Notes
 

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import docdown.workdir as workdir_module
 from docdown.workdir import WorkDir, WorkDirError
 
 
@@ -56,6 +57,32 @@ def test_stage_input_creates_structure_when_missing(tmp_path):
     assert workdir.input_dir.is_dir()
     assert staged == workdir.input_dir / "source.pdf"
     assert staged.exists()
+
+
+def test_stage_input_copy_fallback_is_idempotent(tmp_path, monkeypatch):
+    source = tmp_path / "source.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    original_copy2 = workdir_module.shutil.copy2
+    copy_calls = 0
+
+    def _failing_symlink(self, target):
+        raise OSError("symlink disabled")
+
+    def _counting_copy(src, dst, *, follow_symlinks=True):
+        nonlocal copy_calls
+        copy_calls += 1
+        return original_copy2(src, dst, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(Path, "symlink_to", _failing_symlink)
+    monkeypatch.setattr("docdown.workdir.shutil.copy2", _counting_copy)
+
+    first = workdir.stage_input(source)
+    second = workdir.stage_input(source)
+
+    assert first == second
+    assert copy_calls == 1
 
 
 def test_artifact_path_generation_for_chunk_outputs(tmp_path):

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -46,6 +46,18 @@ def test_stage_input_symlink_or_copy_into_input_directory(tmp_path):
     assert staged.read_bytes() == source.read_bytes()
 
 
+def test_stage_input_creates_structure_when_missing(tmp_path):
+    source = tmp_path / "source.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    staged = workdir.stage_input(source)
+
+    assert workdir.input_dir.is_dir()
+    assert staged == workdir.input_dir / "source.pdf"
+    assert staged.exists()
+
+
 def test_artifact_path_generation_for_chunk_outputs(tmp_path):
     workdir = WorkDir(tmp_path / "output")
 

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -92,3 +92,18 @@ def test_ensure_structure_rejects_file_as_workdir(tmp_path):
 
     with pytest.raises(WorkDirError, match="workdir must be a directory"):
         WorkDir(not_dir).ensure_structure()
+
+
+def test_ensure_structure_wraps_oserror(tmp_path, monkeypatch):
+    workdir = WorkDir(tmp_path / "output")
+    original_mkdir = Path.mkdir
+
+    def _failing_mkdir(self, *args, **kwargs):
+        if self == workdir.base:
+            raise PermissionError("permission denied")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _failing_mkdir)
+
+    with pytest.raises(WorkDirError, match="failed to create workdir structure"):
+        workdir.ensure_structure()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -107,3 +107,46 @@ def test_ensure_structure_wraps_oserror(tmp_path, monkeypatch):
 
     with pytest.raises(WorkDirError, match="failed to create workdir structure"):
         workdir.ensure_structure()
+
+
+def test_stage_input_wraps_unlink_oserror(tmp_path, monkeypatch):
+    source_a = tmp_path / "a.pdf"
+    source_b = tmp_path / "b.pdf"
+    source_a.write_bytes(b"%PDF-1.4 A\n")
+    source_b.write_bytes(b"%PDF-1.4 B\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    workdir.ensure_structure()
+    workdir.stage_input(source_a)
+
+    original_unlink = Path.unlink
+
+    def _failing_unlink(self, *args, **kwargs):
+        if self == workdir.input_dir / "source.pdf":
+            raise PermissionError("cannot remove")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _failing_unlink)
+
+    with pytest.raises(WorkDirError, match="failed to replace staged input"):
+        workdir.stage_input(source_b)
+
+
+def test_stage_input_wraps_copy_oserror(tmp_path, monkeypatch):
+    source = tmp_path / "source.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    workdir.ensure_structure()
+
+    def _failing_symlink(self, target):
+        raise OSError("symlink disabled")
+
+    def _failing_copy(src, dst, *, follow_symlinks=True):
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(Path, "symlink_to", _failing_symlink)
+    monkeypatch.setattr("docdown.workdir.shutil.copy2", _failing_copy)
+
+    with pytest.raises(WorkDirError, match="failed to stage input into"):
+        workdir.stage_input(source)

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -1,0 +1,94 @@
+"""Tests for workdir management helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from docdown.workdir import WorkDir, WorkDirError
+
+
+def test_workdir_creates_expected_subdirectories(tmp_path):
+    workdir = WorkDir(tmp_path / "output")
+    workdir.ensure_structure()
+
+    assert workdir.base.exists()
+    assert workdir.input_dir.is_dir()
+    assert workdir.chunks_dir.is_dir()
+    assert workdir.extracted_dir.is_dir()
+    assert workdir.markdown_dir.is_dir()
+    assert workdir.tables_dir.is_dir()
+
+
+def test_workdir_resume_keeps_existing_files(tmp_path):
+    workdir = WorkDir(tmp_path / "output")
+    workdir.ensure_structure()
+
+    marker = workdir.markdown_dir / "keep.md"
+    marker.write_text("existing", encoding="utf-8")
+
+    workdir.ensure_structure()
+
+    assert marker.exists()
+    assert marker.read_text(encoding="utf-8") == "existing"
+
+
+def test_stage_input_symlink_or_copy_into_input_directory(tmp_path):
+    source = tmp_path / "source.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    workdir.ensure_structure()
+
+    staged = workdir.stage_input(source)
+
+    assert staged == workdir.input_dir / "source.pdf"
+    assert staged.exists()
+    assert staged.read_bytes() == source.read_bytes()
+
+
+def test_artifact_path_generation_for_chunk_outputs(tmp_path):
+    workdir = WorkDir(tmp_path / "output")
+
+    assert workdir.chunk_pdf(3) == workdir.base / "chunks" / "chunk-0003.pdf"
+    assert workdir.extracted(3) == workdir.base / "extracted" / "chunk-0003.xml"
+    assert workdir.markdown(3) == workdir.base / "markdown" / "chunk-0003.md"
+    assert workdir.table_markdown(3, 2) == workdir.base / "tables" / "chunk-0003-table-002.md"
+    assert workdir.merged_markdown() == workdir.base / "merged.md"
+    assert workdir.final_markdown() == workdir.base / "final.md"
+
+
+def test_artifact_path_rejects_invalid_inputs(tmp_path):
+    workdir = WorkDir(tmp_path / "output")
+
+    with pytest.raises(WorkDirError, match="chunk_number must be >= 1"):
+        workdir.artifact_path("chunks", 0)
+
+    with pytest.raises(WorkDirError, match="require table_number"):
+        workdir.artifact_path("tables", 1)
+
+    with pytest.raises(WorkDirError, match="unknown artifact_type"):
+        workdir.artifact_path("unknown", 1)
+
+
+def test_stage_input_replaces_previous_staged_file(tmp_path):
+    source_a = tmp_path / "a.pdf"
+    source_b = tmp_path / "b.pdf"
+    source_a.write_bytes(b"%PDF-1.4 A\n")
+    source_b.write_bytes(b"%PDF-1.4 B\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    workdir.ensure_structure()
+
+    first = workdir.stage_input(source_a)
+    second = workdir.stage_input(source_b)
+
+    assert first == second
+    assert second.read_bytes() == source_b.read_bytes()
+
+
+def test_ensure_structure_rejects_file_as_workdir(tmp_path):
+    not_dir = tmp_path / "not-dir"
+    not_dir.write_text("x", encoding="utf-8")
+
+    with pytest.raises(WorkDirError, match="workdir must be a directory"):
+        WorkDir(not_dir).ensure_structure()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -108,6 +108,24 @@ def test_artifact_path_rejects_invalid_inputs(tmp_path):
     with pytest.raises(WorkDirError, match="unknown artifact_type"):
         workdir.artifact_path("unknown", 1)
 
+    with pytest.raises(WorkDirError, match="ext must not contain path separators"):
+        workdir.extracted(1, "../xml")
+
+    with pytest.raises(WorkDirError, match="ext must not contain path separators"):
+        workdir.markdown(1, "nested/md")
+
+    with pytest.raises(WorkDirError, match="ext must not contain path separators"):
+        workdir.table_markdown(1, 1, "bad\\md")
+
+    with pytest.raises(WorkDirError, match="ext must not be empty"):
+        workdir.extracted(1, ".")
+
+
+def test_artifact_path_normalizes_leading_dot_extension(tmp_path):
+    workdir = WorkDir(tmp_path / "output")
+
+    assert workdir.extracted(2, ".tei") == workdir.base / "extracted" / "chunk-0002.tei"
+
 
 def test_stage_input_replaces_previous_staged_file(tmp_path):
     source_a = tmp_path / "a.pdf"


### PR DESCRIPTION
## Summary
- add WorkDir helper for workdir structure and artifact path generation
- initialize workdir in CLI startup and stage input PDF into input/source.pdf
- add unit tests for directory creation, resume behavior, path helpers, and error cases
- mark Task 1.4 checklist complete in plan doc

## Testing
- python -m pytest -q tests/test_workdir.py tests/test_cli.py
- python -m pytest -q