### PR TITLE
Task 2.1: PDF validation and page counting

### DIFF
--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -3,6 +3,7 @@
 import click
 
 from docdown.config import ConfigError, load_config
+from docdown.stages.split import PdfValidationError, validate_pdf
 from docdown.utils.logging import configure_logging
 from docdown.workdir import WorkDir, WorkDirError
 
@@ -103,6 +104,13 @@ def main(
     logger.info(input_text)
     logger.info(workdir_text)
     logger.debug("Staged input at %s", staged_input)
+
+    try:
+        validation = validate_pdf(staged_input, logger=logger)
+    except PdfValidationError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    logger.info("PDF ready for splitting: pages=%s size_bytes=%s", validation.page_count, validation.file_size_bytes)
 
 
 def _version():

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -10,96 +10,96 @@ import subprocess
 
 @dataclass(frozen=True)
 class PdfValidationResult:
-	"""Validation metadata extracted from qpdf before splitting."""
+    """Validation metadata extracted from qpdf before splitting."""
 
-	page_count: int
-	file_size_bytes: int
+    page_count: int
+    file_size_bytes: int
 
 
 class PdfValidationError(ValueError):
-	"""Raised when input PDF cannot be validated for processing."""
+    """Raised when input PDF cannot be validated for processing."""
 
 
 def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.Logger | None = None) -> PdfValidationResult:
-	"""Validate PDF with qpdf and return page-count metadata."""
+    """Validate PDF with qpdf and return page-count metadata."""
 
-	input_path = Path(input_pdf)
-	if not input_path.exists() or not input_path.is_file():
-		raise PdfValidationError(f"Input PDF not found: {input_path}")
+    input_path = Path(input_pdf)
+    if not input_path.exists() or not input_path.is_file():
+        raise PdfValidationError(f"Input PDF not found: {input_path}")
 
-	active_logger = logger or logging.getLogger()
-	encrypted = _is_encrypted(input_path, password)
-	if encrypted and not password:
-		raise PdfValidationError(
-			"Input PDF is encrypted and requires a password. "
-			"Provide a PDF password before running DocDown."
-		)
+    active_logger = logger or logging.getLogger()
+    encrypted = _is_encrypted(input_path, password)
+    if encrypted and not password:
+        raise PdfValidationError(
+            "Input PDF is encrypted and requires a password. "
+            "Provide a PDF password before running DocDown."
+        )
 
-	check_result = _run_qpdf(_qpdf_command("--check", input_path, password=password))
-	if check_result.returncode == 2:
-		diagnostics = _combined_output(check_result)
-		raise PdfValidationError(f"Invalid or corrupted PDF: {diagnostics}")
-	if check_result.returncode not in (0, 3):
-		diagnostics = _combined_output(check_result)
-		raise PdfValidationError(f"qpdf validation failed (exit {check_result.returncode}): {diagnostics}")
-	if check_result.returncode == 3:
-		active_logger.warning("qpdf reported warnings but PDF is usable: %s", _combined_output(check_result))
+    check_result = _run_qpdf(_qpdf_command("--check", input_path, password=password))
+    if check_result.returncode == 2:
+        diagnostics = _combined_output(check_result)
+        raise PdfValidationError(f"Invalid or corrupted PDF: {diagnostics}")
+    if check_result.returncode not in (0, 3):
+        diagnostics = _combined_output(check_result)
+        raise PdfValidationError(f"qpdf validation failed (exit {check_result.returncode}): {diagnostics}")
+    if check_result.returncode == 3:
+        active_logger.warning("qpdf reported warnings but PDF is usable: %s", _combined_output(check_result))
 
-	count_result = _run_qpdf(_qpdf_command("--show-npages", input_path, password=password))
-	if count_result.returncode != 0:
-		diagnostics = _combined_output(count_result)
-		raise PdfValidationError(f"Could not determine PDF page count: {diagnostics}")
+    count_result = _run_qpdf(_qpdf_command("--show-npages", input_path, password=password))
+    if count_result.returncode != 0:
+        diagnostics = _combined_output(count_result)
+        raise PdfValidationError(f"Could not determine PDF page count: {diagnostics}")
 
-	page_count = _parse_page_count(count_result.stdout)
-	file_size = input_path.stat().st_size
-	active_logger.info("Validated PDF: pages=%s size_bytes=%s", page_count, file_size)
+    page_count = _parse_page_count(count_result.stdout)
+    file_size = input_path.stat().st_size
+    active_logger.info("Validated PDF: pages=%s size_bytes=%s", page_count, file_size)
 
-	return PdfValidationResult(page_count=page_count, file_size_bytes=file_size)
+    return PdfValidationResult(page_count=page_count, file_size_bytes=file_size)
 
 
 def _is_encrypted(input_path: Path, password: str | None) -> bool:
-	result = _run_qpdf(_qpdf_command("--show-encryption", input_path, password=password))
-	combined = _combined_output(result).lower()
+    result = _run_qpdf(_qpdf_command("--show-encryption", input_path, password=password))
+    combined = _combined_output(result).lower()
 
-	if "not encrypted" in combined:
-		return False
-	if "encrypted" in combined:
-		return True
+    if "not encrypted" in combined:
+        return False
+    if "encrypted" in combined:
+        return True
 
-	# When qpdf can't determine encryption state, keep flow strict.
-	if result.returncode != 0:
-		raise PdfValidationError(f"Could not determine encryption status: {_combined_output(result)}")
+    # When qpdf can't determine encryption state, keep flow strict.
+    if result.returncode != 0:
+        raise PdfValidationError(f"Could not determine encryption status: {_combined_output(result)}")
 
-	return False
+    return False
 
 
 def _qpdf_command(flag: str, input_path: Path, *, password: str | None = None) -> list[str]:
-	command = ["qpdf"]
-	if password:
-		command.append(f"--password={password}")
-	command.extend([flag, str(input_path)])
-	return command
+    command = ["qpdf"]
+    if password:
+        command.append(f"--password={password}")
+    command.extend([flag, str(input_path)])
+    return command
 
 
 def _run_qpdf(command: list[str]) -> subprocess.CompletedProcess[str]:
-	try:
-		return subprocess.run(command, capture_output=True, text=True, check=False)
-	except OSError as exc:
-		raise PdfValidationError(f"Failed to execute qpdf command {' '.join(command)}: {exc}") from exc
+    try:
+        return subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise PdfValidationError(f"Failed to execute qpdf command {' '.join(command)}: {exc}") from exc
 
 
 def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
-	combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
-	return combined if combined else "<no diagnostics>"
+    combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+    return combined if combined else "<no diagnostics>"
 
 
 def _parse_page_count(stdout: str) -> int:
-	text = stdout.strip()
-	try:
-		page_count = int(text)
-	except ValueError as exc:
-		raise PdfValidationError(f"Unexpected qpdf --show-npages output: {stdout!r}") from exc
+    text = stdout.strip()
+    try:
+        page_count = int(text)
+    except ValueError as exc:
+        raise PdfValidationError(f"Unexpected qpdf --show-npages output: {stdout!r}") from exc
 
-	if page_count < 1:
-		raise PdfValidationError(f"qpdf reported invalid page count: {page_count}")
-	return page_count
+    if page_count < 1:
+        raise PdfValidationError(f"qpdf reported invalid page count: {page_count}")
+    return page_count

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -1,1 +1,105 @@
-"""Stage 1 — PDF splitting."""
+"""Stage 1 — PDF validation and splitting helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import subprocess
+
+
+@dataclass(frozen=True)
+class PdfValidationResult:
+	"""Validation metadata extracted from qpdf before splitting."""
+
+	page_count: int
+	file_size_bytes: int
+
+
+class PdfValidationError(ValueError):
+	"""Raised when input PDF cannot be validated for processing."""
+
+
+def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.Logger | None = None) -> PdfValidationResult:
+	"""Validate PDF with qpdf and return page-count metadata."""
+
+	input_path = Path(input_pdf)
+	if not input_path.exists() or not input_path.is_file():
+		raise PdfValidationError(f"Input PDF not found: {input_path}")
+
+	active_logger = logger or logging.getLogger()
+	encrypted = _is_encrypted(input_path, password)
+	if encrypted and not password:
+		raise PdfValidationError(
+			"Input PDF is encrypted and requires a password. "
+			"Provide a PDF password before running DocDown."
+		)
+
+	check_result = _run_qpdf(_qpdf_command("--check", input_path, password=password))
+	if check_result.returncode == 2:
+		diagnostics = _combined_output(check_result)
+		raise PdfValidationError(f"Invalid or corrupted PDF: {diagnostics}")
+	if check_result.returncode not in (0, 3):
+		diagnostics = _combined_output(check_result)
+		raise PdfValidationError(f"qpdf validation failed (exit {check_result.returncode}): {diagnostics}")
+	if check_result.returncode == 3:
+		active_logger.warning("qpdf reported warnings but PDF is usable: %s", _combined_output(check_result))
+
+	count_result = _run_qpdf(_qpdf_command("--show-npages", input_path, password=password))
+	if count_result.returncode != 0:
+		diagnostics = _combined_output(count_result)
+		raise PdfValidationError(f"Could not determine PDF page count: {diagnostics}")
+
+	page_count = _parse_page_count(count_result.stdout)
+	file_size = input_path.stat().st_size
+	active_logger.info("Validated PDF: pages=%s size_bytes=%s", page_count, file_size)
+
+	return PdfValidationResult(page_count=page_count, file_size_bytes=file_size)
+
+
+def _is_encrypted(input_path: Path, password: str | None) -> bool:
+	result = _run_qpdf(_qpdf_command("--show-encryption", input_path, password=password))
+	combined = _combined_output(result).lower()
+
+	if "not encrypted" in combined:
+		return False
+	if "encrypted" in combined:
+		return True
+
+	# When qpdf can't determine encryption state, keep flow strict.
+	if result.returncode != 0:
+		raise PdfValidationError(f"Could not determine encryption status: {_combined_output(result)}")
+
+	return False
+
+
+def _qpdf_command(flag: str, input_path: Path, *, password: str | None = None) -> list[str]:
+	command = ["qpdf"]
+	if password:
+		command.append(f"--password={password}")
+	command.extend([flag, str(input_path)])
+	return command
+
+
+def _run_qpdf(command: list[str]) -> subprocess.CompletedProcess[str]:
+	try:
+		return subprocess.run(command, capture_output=True, text=True, check=False)
+	except OSError as exc:
+		raise PdfValidationError(f"Failed to execute qpdf command {' '.join(command)}: {exc}") from exc
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+	combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+	return combined if combined else "<no diagnostics>"
+
+
+def _parse_page_count(stdout: str) -> int:
+	text = stdout.strip()
+	try:
+		page_count = int(text)
+	except ValueError as exc:
+		raise PdfValidationError(f"Unexpected qpdf --show-npages output: {stdout!r}") from exc
+
+	if page_count < 1:
+		raise PdfValidationError(f"qpdf reported invalid page count: {page_count}")
+	return page_count

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -31,7 +31,7 @@ def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.L
 
     active_logger = logger or get_logger()
     encrypted = _is_encrypted(input_path, password)
-    if encrypted and not password:
+    if encrypted and password is None:
         raise PdfValidationError(
             "Input PDF is encrypted and requires a password. "
             "Provide a PDF password before running DocDown."
@@ -77,7 +77,7 @@ def _is_encrypted(input_path: Path, password: str | None) -> bool:
 
 def _qpdf_command(flag: str, input_path: Path, *, password: str | None = None) -> list[str]:
     command = ["qpdf"]
-    if password:
+    if password is not None:
         command.append(f"--password={password}")
     command.extend([flag, str(input_path)])
     return command

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -87,7 +87,19 @@ def _run_qpdf(command: list[str]) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(command, capture_output=True, text=True, check=False)
     except OSError as exc:
-        raise PdfValidationError(f"Failed to execute qpdf command {' '.join(command)}: {exc}") from exc
+        raise PdfValidationError(f"Failed to execute qpdf command {_redact_command(command)}: {exc}") from exc
+
+
+def _redact_command(command: list[str]) -> str:
+    """Render command text while redacting sensitive password arguments."""
+
+    redacted: list[str] = []
+    for part in command:
+        if part.startswith("--password="):
+            redacted.append("--password=***")
+        else:
+            redacted.append(part)
+    return " ".join(redacted)
 
 
 def _combined_output(result: subprocess.CompletedProcess[str]) -> str:

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import os
 from pathlib import Path
 import subprocess
+import tempfile
 
 from docdown.utils.logging import get_logger, log_tool_command
 
@@ -37,7 +39,7 @@ def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.L
             "Provide a PDF password before running DocDown."
         )
 
-    check_result = _run_qpdf(_qpdf_command("--check", input_path, password=password))
+    check_result = _run_qpdf(_qpdf_command("--check", input_path), password=password)
     if check_result.returncode == 2:
         diagnostics = _combined_output(check_result)
         raise PdfValidationError(f"Invalid or corrupted PDF: {diagnostics}")
@@ -47,7 +49,7 @@ def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.L
     if check_result.returncode == 3:
         active_logger.warning("qpdf reported warnings but PDF is usable: %s", _combined_output(check_result))
 
-    count_result = _run_qpdf(_qpdf_command("--show-npages", input_path, password=password))
+    count_result = _run_qpdf(_qpdf_command("--show-npages", input_path), password=password)
     if count_result.returncode != 0:
         diagnostics = _combined_output(count_result)
         raise PdfValidationError(f"Could not determine PDF page count: {diagnostics}")
@@ -60,7 +62,7 @@ def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.L
 
 
 def _is_encrypted(input_path: Path, password: str | None) -> bool:
-    result = _run_qpdf(_qpdf_command("--show-encryption", input_path, password=password))
+    result = _run_qpdf(_qpdf_command("--show-encryption", input_path), password=password)
     combined = _combined_output(result).lower()
 
     if "not encrypted" in combined:
@@ -75,20 +77,48 @@ def _is_encrypted(input_path: Path, password: str | None) -> bool:
     return False
 
 
-def _qpdf_command(flag: str, input_path: Path, *, password: str | None = None) -> list[str]:
-    command = ["qpdf"]
-    if password is not None:
-        command.append(f"--password={password}")
-    command.extend([flag, str(input_path)])
-    return command
+def _qpdf_command(flag: str, input_path: Path) -> list[str]:
+    return ["qpdf", flag, str(input_path)]
 
 
-def _run_qpdf(command: list[str]) -> subprocess.CompletedProcess[str]:
-    log_tool_command(_redact_command(command))
+def _run_qpdf(command: list[str], *, password: str | None = None) -> subprocess.CompletedProcess[str]:
+    command_to_run, password_file = _inject_password(command, password)
+    log_tool_command(_redact_command(command_to_run))
     try:
-        return subprocess.run(command, capture_output=True, text=True, check=False)
+        return subprocess.run(command_to_run, capture_output=True, text=True, check=False)
     except OSError as exc:
-        raise PdfValidationError(f"Failed to execute qpdf command {_redact_command(command)}: {exc}") from exc
+        raise PdfValidationError(f"Failed to execute qpdf command {_redact_command(command_to_run)}: {exc}") from exc
+    finally:
+        _cleanup_password_file(password_file)
+
+
+def _inject_password(command: list[str], password: str | None) -> tuple[list[str], Path | None]:
+    """Attach password to qpdf command, preferring --password-file over argv."""
+
+    if password is None:
+        return list(command), None
+
+    try:
+        handle, path_text = tempfile.mkstemp(prefix="docdown-qpdf-", suffix=".pwd", text=True)
+        with os.fdopen(handle, "w", encoding="utf-8", newline="\n") as password_file:
+            password_file.write(password)
+            password_file.write("\n")
+        path = Path(path_text)
+        return [command[0], f"--password-file={path}", *command[1:]], path
+    except OSError:
+        # Fallback for environments where temporary files cannot be created.
+        return [command[0], f"--password={password}", *command[1:]], None
+
+
+def _cleanup_password_file(password_file: Path | None) -> None:
+    """Best-effort cleanup for temporary password files used by qpdf."""
+
+    if password_file is None:
+        return
+    try:
+        password_file.unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def _redact_command(command: list[str]) -> str:

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 import subprocess
 
-from docdown.utils.logging import get_logger
+from docdown.utils.logging import get_logger, log_tool_command
 
 
 @dataclass(frozen=True)
@@ -84,6 +84,7 @@ def _qpdf_command(flag: str, input_path: Path, *, password: str | None = None) -
 
 
 def _run_qpdf(command: list[str]) -> subprocess.CompletedProcess[str]:
+    log_tool_command(_redact_command(command))
     try:
         return subprocess.run(command, capture_output=True, text=True, check=False)
     except OSError as exc:

--- a/docdown/stages/split.py
+++ b/docdown/stages/split.py
@@ -7,6 +7,8 @@ import logging
 from pathlib import Path
 import subprocess
 
+from docdown.utils.logging import get_logger
+
 
 @dataclass(frozen=True)
 class PdfValidationResult:
@@ -27,7 +29,7 @@ def validate_pdf(input_pdf: Path, password: str | None = None, logger: logging.L
     if not input_path.exists() or not input_path.is_file():
         raise PdfValidationError(f"Input PDF not found: {input_path}")
 
-    active_logger = logger or logging.getLogger()
+    active_logger = logger or get_logger()
     encrypted = _is_encrypted(input_path, password)
     if encrypted and not password:
         raise PdfValidationError(

--- a/docs/plan/task-1.4-workdir-management.md
+++ b/docs/plan/task-1.4-workdir-management.md
@@ -57,6 +57,82 @@ class WorkDir:
     # etc.
 ```
 
+### Artifact Class Diagram
+
+```mermaid
+classDiagram
+    class WorkDirError {
+        <<exception>>
+    }
+
+    class WorkDir {
+        +Path base
+        +Path input_dir
+        +Path chunks_dir
+        +Path extracted_dir
+        +Path markdown_dir
+        +Path tables_dir
+        +ensure_structure() None
+        +stage_input(source_pdf) Path
+        +artifact_path(artifact_type, chunk_number, ext, table_number) Path
+        +chunk_pdf(chunk_number) Path
+        +extracted(chunk_number, ext) Path
+        +markdown(chunk_number, ext) Path
+        +table_markdown(chunk_number, table_number, ext) Path
+        +merged_markdown() Path
+        +final_markdown() Path
+    }
+
+    class WorkdirModule {
+        <<module: docdown/workdir.py>>
+        +_copy_manifest_matches(source, target, manifest_path) bool
+        +_write_copy_manifest(manifest_path, source, target) None
+        +_read_manifest(manifest_path) dict?
+        +_delete_manifest_if_exists(manifest_path) None
+        +_normalize_extension(ext) str
+    }
+
+    class CliMain {
+        <<module: docdown/cli.py>>
+        +main(..., workdir) None
+    }
+
+    class SplitStage {
+        <<module: docdown/stages/split.py>>
+        +validate_pdf(input_pdf, password, logger) PdfValidationResult
+    }
+
+    class InputArtifacts {
+        <<workdir/input>>
+        +source.pdf
+        +source.manifest.json
+    }
+
+    class OutputArtifacts {
+        <<workdir outputs>>
+        +chunks/chunk-NNNN.pdf
+        +extracted/chunk-NNNN.xml
+        +markdown/chunk-NNNN.md
+        +tables/chunk-NNNN-table-NNN.md
+        +merged.md
+        +final.md
+        +run.log
+    }
+
+    class TestWorkDir {
+        <<tests/test_workdir.py>>
+        +structure/staging/path/error coverage
+    }
+
+    WorkdirModule --> WorkDir : defines
+    WorkdirModule ..> WorkDirError : raises
+    CliMain ..> WorkDir : initializes/stages input
+    SplitStage ..> WorkDir : consumes staged input layout
+    WorkDir --> InputArtifacts : manages
+    WorkDir --> OutputArtifacts : generates paths
+    TestWorkDir ..> WorkdirModule : verifies behavior
+```
+
 ## References
 
 - [technical-design.md §3 — Directory & File Layout](../technical-design.md)

--- a/docs/plan/task-2.1-pdf-validation.md
+++ b/docs/plan/task-2.1-pdf-validation.md
@@ -10,13 +10,17 @@ Validate the input PDF and determine its total page count before splitting.
 
 ## Acceptance Criteria
 
-- [ ] Input file existence is verified; clear error if missing.
-- [ ] Input file is validated as a valid PDF (`qpdf --check`).
-- [ ] Corrupted PDFs produce a clear fatal error with the `qpdf` diagnostic output.
-- [ ] Encrypted PDFs are detected; if a password is not provided, abort with a message.
-- [ ] Total page count is extracted (`qpdf --show-npages`).
-- [ ] Page count and file size are logged at `INFO` level.
-- [ ] Unit tests cover: valid PDF, missing file, corrupted file, encrypted file.
+- [x] Input file existence is verified; clear error if missing.
+- [x] Input file is validated as a valid PDF (`qpdf --check`).
+- [x] Corrupted PDFs produce a clear fatal error with the `qpdf` diagnostic output.
+- [x] Encrypted PDFs are detected; if a password is not provided, abort with a message.
+- [x] Total page count is extracted (`qpdf --show-npages`).
+- [x] Page count and file size are logged at `INFO` level.
+- [x] Unit tests cover: valid PDF, missing file, corrupted file, encrypted file.
+
+Implemented in:
+- `docdown/stages/split.py`
+- `tests/test_split.py`
 
 ## Implementation Notes
 

--- a/docs/plan/task-2.1-pdf-validation.md
+++ b/docs/plan/task-2.1-pdf-validation.md
@@ -16,7 +16,7 @@ Validate the input PDF and determine its total page count before splitting.
 - [x] Encrypted PDFs are detected; if a password is not provided, abort with a message.
 - [x] Total page count is extracted (`qpdf --show-npages`).
 - [x] Page count and file size are logged at `INFO` level.
-- [x] Unit tests cover: valid PDF, missing file, corrupted file, encrypted file.
+- [x] Unit tests cover: valid PDF, missing file, corrupted file, encrypted file, page-count parsing failure.
 
 Implemented in:
 - `docdown/stages/split.py`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,21 @@
 """Tests for the CLI entry point."""
 
+from types import SimpleNamespace
+
 from click.testing import CliRunner
 from docdown import __version__
 from docdown.cli import main
+from docdown.stages.split import PdfValidationError
 
 
-def test_cli_shows_version(tmp_path):
+def test_cli_shows_version(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -40,11 +48,35 @@ def test_cli_rejects_file_path_for_workdir(tmp_path):
     assert "Invalid value" in result.output
 
 
-def test_cli_accepts_log_level_flag(tmp_path):
+def test_cli_accepts_log_level_flag(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--log-level", "debug"])
 
     assert result.exit_code == 0
+
+
+def test_cli_surfaces_pdf_validation_errors(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    def _raise_validation_error(*args, **kwargs):
+        raise PdfValidationError("invalid pdf")
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        _raise_validation_error,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "invalid pdf" in result.output

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 import subprocess
 
 import pytest

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -80,6 +80,31 @@ def test_validate_pdf_encrypted_without_password_aborts(tmp_path, monkeypatch):
         validate_pdf(input_pdf, password=None)
 
 
+def test_validate_pdf_encrypted_with_empty_password_is_allowed(tmp_path, monkeypatch):
+    input_pdf = tmp_path / "secret.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
+
+    responses = iter(
+        [
+            _cp(0, stdout="File is encrypted"),
+            _cp(0, stdout="checking passed"),
+            _cp(0, stdout="3\n"),
+        ]
+    )
+    seen_commands: list[list[str]] = []
+
+    def _fake_run(command, capture_output, text, check):
+        seen_commands.append(command)
+        return next(responses)
+
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+
+    result = validate_pdf(input_pdf, password="")
+
+    assert result.page_count == 3
+    assert any(arg == "--password=" for cmd in seen_commands for arg in cmd)
+
+
 def test_validate_pdf_page_count_parse_failure_raises_clear_error(tmp_path, monkeypatch):
     input_pdf = tmp_path / "input.pdf"
     input_pdf.write_bytes(b"%PDF-1.4\n")

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,1 +1,80 @@
-"""Tests for PDF splitting."""
+"""Tests for Stage 1 PDF validation and page counting."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from docdown.stages.split import PdfValidationError, validate_pdf
+
+
+def _cp(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+	return subprocess.CompletedProcess(args=["qpdf"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_validate_pdf_valid_input_logs_page_count_and_size(tmp_path, monkeypatch, caplog):
+	input_pdf = tmp_path / "input.pdf"
+	input_pdf.write_bytes(b"%PDF-1.4\ncontent")
+
+	responses = iter(
+		[
+			_cp(0, stdout="File is not encrypted"),
+			_cp(0, stdout="checking passed"),
+			_cp(0, stdout="12\n"),
+		]
+	)
+
+	def _fake_run(command, capture_output, text, check):
+		return next(responses)
+
+	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+
+	with caplog.at_level(logging.INFO):
+		result = validate_pdf(input_pdf)
+
+	assert result.page_count == 12
+	assert result.file_size_bytes == input_pdf.stat().st_size
+	assert "Validated PDF: pages=12" in caplog.text
+
+
+def test_validate_pdf_missing_file_raises_clear_error(tmp_path):
+	missing = tmp_path / "missing.pdf"
+
+	with pytest.raises(PdfValidationError, match="Input PDF not found"):
+		validate_pdf(missing)
+
+
+def test_validate_pdf_corrupted_file_raises_with_qpdf_diagnostics(tmp_path, monkeypatch):
+	input_pdf = tmp_path / "broken.pdf"
+	input_pdf.write_bytes(b"not a real pdf")
+
+	responses = iter(
+		[
+			_cp(0, stdout="File is not encrypted"),
+			_cp(2, stderr="file is damaged"),
+		]
+	)
+
+	def _fake_run(command, capture_output, text, check):
+		return next(responses)
+
+	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+
+	with pytest.raises(PdfValidationError, match="Invalid or corrupted PDF: file is damaged"):
+		validate_pdf(input_pdf)
+
+
+def test_validate_pdf_encrypted_without_password_aborts(tmp_path, monkeypatch):
+	input_pdf = tmp_path / "secret.pdf"
+	input_pdf.write_bytes(b"%PDF-1.4\n")
+
+	def _fake_run(command, capture_output, text, check):
+		return _cp(0, stdout="File is encrypted")
+
+	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+
+	with pytest.raises(PdfValidationError, match="requires a password"):
+		validate_pdf(input_pdf, password=None)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -31,9 +31,10 @@ def test_validate_pdf_valid_input_logs_page_count_and_size(tmp_path, monkeypatch
 		return next(responses)
 
 	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+	test_logger = logging.getLogger("tests.split")
 
-	with caplog.at_level(logging.INFO):
-		result = validate_pdf(input_pdf)
+	with caplog.at_level(logging.INFO, logger="tests.split"):
+		result = validate_pdf(input_pdf, logger=test_logger)
 
 	assert result.page_count == 12
 	assert result.file_size_bytes == input_pdf.stat().st_size

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -79,3 +79,20 @@ def test_validate_pdf_encrypted_without_password_aborts(tmp_path, monkeypatch):
 
 	with pytest.raises(PdfValidationError, match="requires a password"):
 		validate_pdf(input_pdf, password=None)
+
+
+def test_validate_pdf_redacts_password_in_qpdf_execution_error(tmp_path, monkeypatch):
+	input_pdf = tmp_path / "secret.pdf"
+	input_pdf.write_bytes(b"%PDF-1.4\n")
+
+	def _raise_oserror(command, capture_output, text, check):
+		raise OSError("qpdf not found")
+
+	monkeypatch.setattr("docdown.stages.split.subprocess.run", _raise_oserror)
+
+	with pytest.raises(PdfValidationError) as exc_info:
+		validate_pdf(input_pdf, password="top-secret")
+
+	error_text = str(exc_info.value)
+	assert "--password=***" in error_text
+	assert "top-secret" not in error_text

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -102,7 +102,10 @@ def test_validate_pdf_encrypted_with_empty_password_is_allowed(tmp_path, monkeyp
     result = validate_pdf(input_pdf, password="")
 
     assert result.page_count == 3
-    assert any(arg == "--password=" for cmd in seen_commands for arg in cmd)
+    assert any(
+        any(arg.startswith("--password-file=") or arg == "--password=" for arg in cmd)
+        for cmd in seen_commands
+    )
 
 
 def test_validate_pdf_page_count_parse_failure_raises_clear_error(tmp_path, monkeypatch):
@@ -139,8 +142,8 @@ def test_validate_pdf_redacts_password_in_qpdf_execution_error(tmp_path, monkeyp
         validate_pdf(input_pdf, password="top-secret")
 
     error_text = str(exc_info.value)
-    assert "--password=***" in error_text
     assert "top-secret" not in error_text
+    assert "--password-file=" in error_text or "--password=***" in error_text
 
 
 def test_validate_pdf_logs_redacted_qpdf_commands(tmp_path, monkeypatch):
@@ -168,5 +171,5 @@ def test_validate_pdf_logs_redacted_qpdf_commands(tmp_path, monkeypatch):
     validate_pdf(input_pdf, password="super-secret")
 
     assert len(logged_commands) == 3
-    assert all("--password=***" in cmd for cmd in logged_commands)
+    assert all("--password-file=" in cmd or "--password=***" in cmd for cmd in logged_commands)
     assert all("super-secret" not in cmd for cmd in logged_commands)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -12,137 +12,137 @@ from docdown.stages.split import PdfValidationError, validate_pdf
 
 
 def _cp(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
-	return subprocess.CompletedProcess(args=["qpdf"], returncode=returncode, stdout=stdout, stderr=stderr)
+    return subprocess.CompletedProcess(args=["qpdf"], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 def test_validate_pdf_valid_input_logs_page_count_and_size(tmp_path, monkeypatch, caplog):
-	input_pdf = tmp_path / "input.pdf"
-	input_pdf.write_bytes(b"%PDF-1.4\ncontent")
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\ncontent")
 
-	responses = iter(
-		[
-			_cp(0, stdout="File is not encrypted"),
-			_cp(0, stdout="checking passed"),
-			_cp(0, stdout="12\n"),
-		]
-	)
+    responses = iter(
+        [
+            _cp(0, stdout="File is not encrypted"),
+            _cp(0, stdout="checking passed"),
+            _cp(0, stdout="12\n"),
+        ]
+    )
 
-	def _fake_run(command, capture_output, text, check):
-		return next(responses)
+    def _fake_run(command, capture_output, text, check):
+        return next(responses)
 
-	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
-	test_logger = logging.getLogger("tests.split")
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+    test_logger = logging.getLogger("tests.split")
 
-	with caplog.at_level(logging.INFO, logger="tests.split"):
-		result = validate_pdf(input_pdf, logger=test_logger)
+    with caplog.at_level(logging.INFO, logger="tests.split"):
+        result = validate_pdf(input_pdf, logger=test_logger)
 
-	assert result.page_count == 12
-	assert result.file_size_bytes == input_pdf.stat().st_size
-	assert "Validated PDF: pages=12" in caplog.text
+    assert result.page_count == 12
+    assert result.file_size_bytes == input_pdf.stat().st_size
+    assert "Validated PDF: pages=12" in caplog.text
 
 
 def test_validate_pdf_missing_file_raises_clear_error(tmp_path):
-	missing = tmp_path / "missing.pdf"
+    missing = tmp_path / "missing.pdf"
 
-	with pytest.raises(PdfValidationError, match="Input PDF not found"):
-		validate_pdf(missing)
+    with pytest.raises(PdfValidationError, match="Input PDF not found"):
+        validate_pdf(missing)
 
 
 def test_validate_pdf_corrupted_file_raises_with_qpdf_diagnostics(tmp_path, monkeypatch):
-	input_pdf = tmp_path / "broken.pdf"
-	input_pdf.write_bytes(b"not a real pdf")
+    input_pdf = tmp_path / "broken.pdf"
+    input_pdf.write_bytes(b"not a real pdf")
 
-	responses = iter(
-		[
-			_cp(0, stdout="File is not encrypted"),
-			_cp(2, stderr="file is damaged"),
-		]
-	)
+    responses = iter(
+        [
+            _cp(0, stdout="File is not encrypted"),
+            _cp(2, stderr="file is damaged"),
+        ]
+    )
 
-	def _fake_run(command, capture_output, text, check):
-		return next(responses)
+    def _fake_run(command, capture_output, text, check):
+        return next(responses)
 
-	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
 
-	with pytest.raises(PdfValidationError, match="Invalid or corrupted PDF: file is damaged"):
-		validate_pdf(input_pdf)
+    with pytest.raises(PdfValidationError, match="Invalid or corrupted PDF: file is damaged"):
+        validate_pdf(input_pdf)
 
 
 def test_validate_pdf_encrypted_without_password_aborts(tmp_path, monkeypatch):
-	input_pdf = tmp_path / "secret.pdf"
-	input_pdf.write_bytes(b"%PDF-1.4\n")
+    input_pdf = tmp_path / "secret.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
 
-	def _fake_run(command, capture_output, text, check):
-		return _cp(0, stdout="File is encrypted")
+    def _fake_run(command, capture_output, text, check):
+        return _cp(0, stdout="File is encrypted")
 
-	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
 
-	with pytest.raises(PdfValidationError, match="requires a password"):
-		validate_pdf(input_pdf, password=None)
+    with pytest.raises(PdfValidationError, match="requires a password"):
+        validate_pdf(input_pdf, password=None)
 
 
 def test_validate_pdf_page_count_parse_failure_raises_clear_error(tmp_path, monkeypatch):
-	input_pdf = tmp_path / "input.pdf"
-	input_pdf.write_bytes(b"%PDF-1.4\n")
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
 
-	responses = iter(
-		[
-			_cp(0, stdout="File is not encrypted"),
-			_cp(0, stdout="checking passed"),
-			_cp(0, stdout="not-a-number\n"),
-		]
-	)
+    responses = iter(
+        [
+            _cp(0, stdout="File is not encrypted"),
+            _cp(0, stdout="checking passed"),
+            _cp(0, stdout="not-a-number\n"),
+        ]
+    )
 
-	def _fake_run(command, capture_output, text, check):
-		return next(responses)
+    def _fake_run(command, capture_output, text, check):
+        return next(responses)
 
-	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
 
-	with pytest.raises(PdfValidationError, match="Unexpected qpdf --show-npages output"):
-		validate_pdf(input_pdf)
+    with pytest.raises(PdfValidationError, match="Unexpected qpdf --show-npages output"):
+        validate_pdf(input_pdf)
 
 
 def test_validate_pdf_redacts_password_in_qpdf_execution_error(tmp_path, monkeypatch):
-	input_pdf = tmp_path / "secret.pdf"
-	input_pdf.write_bytes(b"%PDF-1.4\n")
+    input_pdf = tmp_path / "secret.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\n")
 
-	def _raise_oserror(command, capture_output, text, check):
-		raise OSError("qpdf not found")
+    def _raise_oserror(command, capture_output, text, check):
+        raise OSError("qpdf not found")
 
-	monkeypatch.setattr("docdown.stages.split.subprocess.run", _raise_oserror)
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _raise_oserror)
 
-	with pytest.raises(PdfValidationError) as exc_info:
-		validate_pdf(input_pdf, password="top-secret")
+    with pytest.raises(PdfValidationError) as exc_info:
+        validate_pdf(input_pdf, password="top-secret")
 
-	error_text = str(exc_info.value)
-	assert "--password=***" in error_text
-	assert "top-secret" not in error_text
+    error_text = str(exc_info.value)
+    assert "--password=***" in error_text
+    assert "top-secret" not in error_text
 
 
 def test_validate_pdf_logs_redacted_qpdf_commands(tmp_path, monkeypatch):
-	input_pdf = tmp_path / "input.pdf"
-	input_pdf.write_bytes(b"%PDF-1.4\ncontent")
+    input_pdf = tmp_path / "input.pdf"
+    input_pdf.write_bytes(b"%PDF-1.4\ncontent")
 
-	responses = iter(
-		[
-			_cp(0, stdout="File is not encrypted"),
-			_cp(0, stdout="checking passed"),
-			_cp(0, stdout="7\n"),
-		]
-	)
-	logged_commands: list[str] = []
+    responses = iter(
+        [
+            _cp(0, stdout="File is not encrypted"),
+            _cp(0, stdout="checking passed"),
+            _cp(0, stdout="7\n"),
+        ]
+    )
+    logged_commands: list[str] = []
 
-	def _fake_run(command, capture_output, text, check):
-		return next(responses)
+    def _fake_run(command, capture_output, text, check):
+        return next(responses)
 
-	def _capture_tool_command(command, chunk_number=None):
-		logged_commands.append(str(command))
+    def _capture_tool_command(command, chunk_number=None):
+        logged_commands.append(str(command))
 
-	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
-	monkeypatch.setattr("docdown.stages.split.log_tool_command", _capture_tool_command)
+    monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+    monkeypatch.setattr("docdown.stages.split.log_tool_command", _capture_tool_command)
 
-	validate_pdf(input_pdf, password="super-secret")
+    validate_pdf(input_pdf, password="super-secret")
 
-	assert len(logged_commands) == 3
-	assert all("--password=***" in cmd for cmd in logged_commands)
-	assert all("super-secret" not in cmd for cmd in logged_commands)
+    assert len(logged_commands) == 3
+    assert all("--password=***" in cmd for cmd in logged_commands)
+    assert all("super-secret" not in cmd for cmd in logged_commands)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -96,3 +96,32 @@ def test_validate_pdf_redacts_password_in_qpdf_execution_error(tmp_path, monkeyp
 	error_text = str(exc_info.value)
 	assert "--password=***" in error_text
 	assert "top-secret" not in error_text
+
+
+def test_validate_pdf_logs_redacted_qpdf_commands(tmp_path, monkeypatch):
+	input_pdf = tmp_path / "input.pdf"
+	input_pdf.write_bytes(b"%PDF-1.4\ncontent")
+
+	responses = iter(
+		[
+			_cp(0, stdout="File is not encrypted"),
+			_cp(0, stdout="checking passed"),
+			_cp(0, stdout="7\n"),
+		]
+	)
+	logged_commands: list[str] = []
+
+	def _fake_run(command, capture_output, text, check):
+		return next(responses)
+
+	def _capture_tool_command(command, chunk_number=None):
+		logged_commands.append(str(command))
+
+	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+	monkeypatch.setattr("docdown.stages.split.log_tool_command", _capture_tool_command)
+
+	validate_pdf(input_pdf, password="super-secret")
+
+	assert len(logged_commands) == 3
+	assert all("--password=***" in cmd for cmd in logged_commands)
+	assert all("super-secret" not in cmd for cmd in logged_commands)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -81,6 +81,27 @@ def test_validate_pdf_encrypted_without_password_aborts(tmp_path, monkeypatch):
 		validate_pdf(input_pdf, password=None)
 
 
+def test_validate_pdf_page_count_parse_failure_raises_clear_error(tmp_path, monkeypatch):
+	input_pdf = tmp_path / "input.pdf"
+	input_pdf.write_bytes(b"%PDF-1.4\n")
+
+	responses = iter(
+		[
+			_cp(0, stdout="File is not encrypted"),
+			_cp(0, stdout="checking passed"),
+			_cp(0, stdout="not-a-number\n"),
+		]
+	)
+
+	def _fake_run(command, capture_output, text, check):
+		return next(responses)
+
+	monkeypatch.setattr("docdown.stages.split.subprocess.run", _fake_run)
+
+	with pytest.raises(PdfValidationError, match="Unexpected qpdf --show-npages output"):
+		validate_pdf(input_pdf)
+
+
 def test_validate_pdf_redacts_password_in_qpdf_execution_error(tmp_path, monkeypatch):
 	input_pdf = tmp_path / "secret.pdf"
 	input_pdf.write_bytes(b"%PDF-1.4\n")


### PR DESCRIPTION
## Summary
- implement Stage 1 PDF validation in docdown/stages/split.py
- validate input existence and run qpdf --check with clear error mapping
- detect encrypted PDFs and require password before continuing
- extract page count via qpdf --show-npages
- log page count and file size at INFO
- mark Task 2.1 checklist complete in plan doc

## Testing
- python -m pytest -q tests/test_split.py
- python -m pytest -q