### PR TITLE
Task 3.2: pdfminer fallback extraction

### DIFF
--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -1,4 +1,4 @@
-"""Stage 2 — Content extraction via GROBID."""
+"""Stage 2 — Content extraction via GROBID and pdfminer fallback."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 import time
 
+from pdfminer.high_level import extract_text as pdfminer_extract_text
 import requests
 
 from docdown.utils.logging import ChunkAdapter, get_chunk_logger, get_logger
@@ -21,6 +22,10 @@ _MAX_ERROR_BODY_EXCERPT = 300
 
 class GrobidError(ValueError):
     """Raised when GROBID health checks or extraction requests fail."""
+
+
+class PdfMinerError(ValueError):
+    """Raised when pdfminer fallback extraction fails."""
 
 
 def wait_for_grobid(
@@ -161,6 +166,47 @@ def extract_grobid_chunk(
         elapsed = time.monotonic() - started_at
         active_logger.info("GROBID extraction complete for %s in %.2fs", chunk_path.name, elapsed)
         return output_path
+
+
+def extract_pdfminer_chunk(
+    chunk_pdf: Path,
+    output_text: Path,
+    *,
+    logger: logging.Logger | None = None,
+    chunk_number: int | None = None,
+) -> Path:
+    """Extract plain text from a chunk PDF using pdfminer and write UTF-8 text output."""
+
+    chunk_path = Path(chunk_pdf)
+    output_path = Path(output_text)
+
+    active_logger: logging.Logger | ChunkAdapter
+    if chunk_number is not None:
+        active_logger = ChunkAdapter(logger, {"chunk": chunk_number}) if logger else get_chunk_logger(chunk_number)
+    else:
+        active_logger = logger or get_logger()
+
+    if not chunk_path.exists() or not chunk_path.is_file():
+        raise PdfMinerError(f"Chunk PDF not found: {chunk_path}")
+
+    started_at = time.monotonic()
+
+    try:
+        text = pdfminer_extract_text(str(chunk_path))
+    except Exception as exc:
+        active_logger.error("pdfminer extraction failed for %s: %s", chunk_path.name, exc)
+        raise PdfMinerError(f"pdfminer extraction failed for {chunk_path.name}: {exc}") from exc
+
+    if not text.strip():
+        active_logger.error("pdfminer produced empty output for %s", chunk_path.name)
+        raise PdfMinerError(f"pdfminer produced empty output for {chunk_path.name}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding="utf-8")
+
+    elapsed = time.monotonic() - started_at
+    active_logger.info("pdfminer extraction complete for %s in %.2fs", chunk_path.name, elapsed)
+    return output_path
 
 
 def _body_excerpt(text: str, max_chars: int = _MAX_ERROR_BODY_EXCERPT) -> str:

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -186,7 +186,7 @@ def extract_pdfminer_chunk(
     try:
         text = pdfminer_extract_text(str(chunk_path))
     except Exception as exc:
-        active_logger.error("pdfminer extraction failed for %s: %s", chunk_path.name, exc)
+        active_logger.exception("pdfminer extraction failed for %s", chunk_path.name)
         raise PdfMinerError(f"pdfminer extraction failed for {chunk_path.name}: {exc}") from exc
 
     if not text.strip():

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -93,11 +93,7 @@ def extract_grobid_chunk(
     if not chunk_path.exists() or not chunk_path.is_file():
         raise GrobidError(f"Chunk PDF not found: {chunk_path}")
 
-    active_logger: logging.Logger | ChunkAdapter
-    if chunk_number is not None:
-        active_logger = ChunkAdapter(logger, {"chunk": chunk_number}) if logger else get_chunk_logger(chunk_number)
-    else:
-        active_logger = logger or get_logger()
+    active_logger = _resolve_logger(logger, chunk_number)
 
     client = session or requests
     endpoint = f"{grobid_url.rstrip('/')}/api/processFulltextDocument"
@@ -180,11 +176,7 @@ def extract_pdfminer_chunk(
     chunk_path = Path(chunk_pdf)
     output_path = Path(output_text)
 
-    active_logger: logging.Logger | ChunkAdapter
-    if chunk_number is not None:
-        active_logger = ChunkAdapter(logger, {"chunk": chunk_number}) if logger else get_chunk_logger(chunk_number)
-    else:
-        active_logger = logger or get_logger()
+    active_logger = _resolve_logger(logger, chunk_number)
 
     if not chunk_path.exists() or not chunk_path.is_file():
         raise PdfMinerError(f"Chunk PDF not found: {chunk_path}")
@@ -237,3 +229,14 @@ def _body_excerpt(text: str, max_chars: int = _MAX_ERROR_BODY_EXCERPT) -> str:
         return "".join(normalized_chars)
 
     return "".join(normalized_chars[:max_chars]) + "..."
+
+
+def _resolve_logger(
+    logger: logging.Logger | None,
+    chunk_number: int | None,
+) -> logging.Logger | ChunkAdapter:
+    if chunk_number is None:
+        return logger or get_logger()
+    if logger is None:
+        return get_chunk_logger(chunk_number)
+    return ChunkAdapter(logger, {"chunk": chunk_number})

--- a/docs/plan/task-3.2-pdfminer-fallback.md
+++ b/docs/plan/task-3.2-pdfminer-fallback.md
@@ -11,13 +11,17 @@ Implement the fallback content extraction method using `pdfminer.six` for chunks
 
 ## Acceptance Criteria
 
-- [ ] Text is extracted from a chunk PDF using `pdfminer.six` `extract_text`.
-- [ ] Output is written to `workdir/extracted/chunk-NNNN.txt` (note: `.txt`, not `.xml`).
-- [ ] Output encoding is UTF-8.
-- [ ] Extraction that produces empty output is flagged as a failure.
-- [ ] Extraction errors (e.g., codec errors) are caught, logged, and reported as failure.
-- [ ] Extraction time per chunk is logged.
-- [ ] Unit tests cover: successful extraction, empty output, encoding errors.
+- [x] Text is extracted from a chunk PDF using `pdfminer.six` `extract_text`.
+- [x] Output is written to `workdir/extracted/chunk-NNNN.txt` (note: `.txt`, not `.xml`).
+- [x] Output encoding is UTF-8.
+- [x] Extraction that produces empty output is flagged as a failure.
+- [x] Extraction errors (e.g., codec errors) are caught, logged, and reported as failure.
+- [x] Extraction time per chunk is logged.
+- [x] Unit tests cover: successful extraction, empty output, encoding errors.
+
+Implemented in:
+- `docdown/stages/extract.py`
+- `tests/test_extract.py`
 
 ## Implementation Notes
 
@@ -40,6 +44,51 @@ def extract_pdfminer(chunk_path, output_path):
 - Images are ignored.
 
 These limitations mean downstream Pandoc conversion from pdfminer output produces lower-quality Markdown than from GROBID TEI XML.
+
+### Artifact Class Diagram
+
+```mermaid
+classDiagram
+    class PdfMinerError {
+        <<exception>>
+    }
+
+    class ExtractStageModule {
+        <<module: docdown/stages/extract.py>>
+        +extract_pdfminer_chunk(chunk_pdf, output_text, *, logger, chunk_number) Path
+    }
+
+    class LoggingModule {
+        <<module: docdown/utils/logging.py>>
+        +get_logger() Logger
+        +get_chunk_logger(chunk_number) ChunkAdapter
+        +ChunkAdapter
+    }
+
+    class PdfMinerLibrary {
+        <<external: pdfminer.six>>
+        +extract_text(path) str
+    }
+
+    class WorkDirArtifacts {
+        <<workdir artifacts>>
+        +chunks/chunk-NNNN.pdf
+        +extracted/chunk-NNNN.txt
+    }
+
+    class TestExtract {
+        <<tests/test_extract.py>>
+        +pdfminer success test
+        +empty output failure test
+        +extraction error wrapping test
+    }
+
+    ExtractStageModule ..> PdfMinerError : raises
+    ExtractStageModule ..> LoggingModule : uses logger adapters
+    ExtractStageModule ..> PdfMinerLibrary : extracts text
+    ExtractStageModule --> WorkDirArtifacts : reads PDF / writes UTF-8 text
+    TestExtract ..> ExtractStageModule : verifies behavior
+```
 
 ## References
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -263,6 +263,14 @@ def test_extract_pdfminer_chunk_writes_text_and_logs_time(tmp_path, monkeypatch,
     assert "pdfminer extraction complete" in caplog.text
 
 
+def test_extract_pdfminer_chunk_rejects_missing_chunk_file(tmp_path):
+    missing_chunk = tmp_path / "chunk-0001.pdf"
+    output = tmp_path / "chunk-0001.txt"
+
+    with pytest.raises(PdfMinerError, match=r"Chunk PDF not found: .*chunk-0001\.pdf"):
+        extract_pdfminer_chunk(missing_chunk, output)
+
+
 def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):
     chunk = tmp_path / "chunk-0001.pdf"
     output = tmp_path / "chunk-0001.txt"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,4 +1,4 @@
-"""Tests for Stage 2 content extraction via GROBID."""
+"""Tests for Stage 2 content extraction via GROBID and pdfminer fallback."""
 
 from __future__ import annotations
 
@@ -8,7 +8,13 @@ import os
 import pytest
 import requests
 
-from docdown.stages.extract import GrobidError, extract_grobid_chunk, wait_for_grobid
+from docdown.stages.extract import (
+    GrobidError,
+    PdfMinerError,
+    extract_grobid_chunk,
+    extract_pdfminer_chunk,
+    wait_for_grobid,
+)
 
 
 class _Resp:
@@ -236,6 +242,50 @@ def test_extract_grobid_chunk_rejects_negative_backoff_base_seconds(tmp_path):
 
     with pytest.raises(GrobidError, match="backoff_base_seconds must be >= 0"):
         extract_grobid_chunk(chunk, output, "http://localhost:8070", backoff_base_seconds=-1)
+
+
+def test_extract_pdfminer_chunk_writes_text_and_logs_time(tmp_path, monkeypatch, caplog):
+    chunk = tmp_path / "chunk-0001.pdf"
+    output = tmp_path / "extracted" / "chunk-0001.txt"
+    chunk.write_bytes(b"%PDF-1.4\n")
+
+    monkeypatch.setattr(
+        "docdown.stages.extract.pdfminer_extract_text",
+        lambda path: "line 1\nline 2\n",
+    )
+    test_logger = logging.getLogger("tests.extract.pdfminer")
+
+    with caplog.at_level(logging.INFO, logger="tests.extract.pdfminer"):
+        result = extract_pdfminer_chunk(chunk, output, logger=test_logger)
+
+    assert result == output
+    assert output.read_text(encoding="utf-8") == "line 1\nline 2\n"
+    assert "pdfminer extraction complete" in caplog.text
+
+
+def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):
+    chunk = tmp_path / "chunk-0001.pdf"
+    output = tmp_path / "chunk-0001.txt"
+    chunk.write_bytes(b"%PDF-1.4\n")
+
+    monkeypatch.setattr("docdown.stages.extract.pdfminer_extract_text", lambda path: "   \n\t")
+
+    with pytest.raises(PdfMinerError, match="produced empty output"):
+        extract_pdfminer_chunk(chunk, output)
+
+
+def test_extract_pdfminer_chunk_wraps_extraction_errors(tmp_path, monkeypatch):
+    chunk = tmp_path / "chunk-0001.pdf"
+    output = tmp_path / "chunk-0001.txt"
+    chunk.write_bytes(b"%PDF-1.4\n")
+
+    def _raise_error(_path):
+        raise UnicodeError("codec boom")
+
+    monkeypatch.setattr("docdown.stages.extract.pdfminer_extract_text", _raise_error)
+
+    with pytest.raises(PdfMinerError, match="pdfminer extraction failed"):
+        extract_pdfminer_chunk(chunk, output)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add `extract_pdfminer_chunk` fallback extraction in `docdown/stages/extract.py`
- add `PdfMinerError` with clear failure messages for missing chunk files, empty output, and extraction exceptions
- write fallback output as UTF-8 text to `.txt` artifacts and log extraction timing
- add unit tests for pdfminer success, empty output failure, and error wrapping
- update Task 3.2 checklist and add artifact class diagram

## Testing
- `pytest tests/test_extract.py -q`
- `pytest -q`

## Notes
- pdfminer fallback is implemented in Stage 2 extraction module for use by extraction orchestration in the next task.