### PR TITLE
Task 3.3: extraction orchestration and fallback logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 
 # DocDown working directories
 output/
+runs/

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -408,7 +408,7 @@ def _body_excerpt(text: str, max_chars: int = _MAX_ERROR_BODY_EXCERPT) -> str:
 def _resolve_logger(
     logger: LogLike | None,
     chunk_number: int | None,
-) -> LogLike | ChunkAdapter:
+) -> LogLike:
     if chunk_number is None:
         return logger or get_logger()
     if logger is None:

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -21,7 +21,6 @@ _DEFAULT_GROBID_POLL_INTERVAL_SECONDS = 2
 _DEFAULT_503_RETRIES = 3
 _DEFAULT_503_BACKOFF_BASE_SECONDS = 5
 _MAX_ERROR_BODY_EXCERPT = 300
-_VALID_EXTRACTORS = {"grobid", "pdfminer"}
 _CHUNK_STEM_PATTERN = re.compile(r"^chunk-(\d{4})$")
 
 LogLike = logging.Logger | logging.LoggerAdapter
@@ -38,6 +37,9 @@ class PdfMinerError(ValueError):
 class ExtractorUsed(str, Enum):
     GROBID = "grobid"
     PDFMINER = "pdfminer"
+
+
+_VALID_EXTRACTORS = {member.value for member in ExtractorUsed}
 
 
 @dataclass(frozen=True)

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -250,7 +250,8 @@ def orchestrate_extraction(
             grobid_available = False
             grobid_unavailable_reason = str(exc)
             active_logger.warning(
-                "GROBID unavailable; using fallback extractor '%s' for all chunks: %s",
+                "GROBID unavailable; skipping all grobid extraction attempts (extractor=%s, fallback=%s): %s",
+                extractor,
                 fallback_extractor,
                 exc,
             )

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -238,12 +238,15 @@ def orchestrate_extraction(
     output_root = Path(extracted_dir)
     output_root.mkdir(parents=True, exist_ok=True)
 
+    grobid_required = extractor == ExtractorUsed.GROBID.value or fallback_extractor == ExtractorUsed.GROBID.value
     grobid_available = True
-    if extractor == ExtractorUsed.GROBID.value:
+    grobid_unavailable_reason: str | None = None
+    if grobid_required:
         try:
             wait_for_grobid(grobid_url, logger=active_logger)
         except GrobidError as exc:
             grobid_available = False
+            grobid_unavailable_reason = str(exc)
             active_logger.warning(
                 "GROBID unavailable; using fallback extractor '%s' for all chunks: %s",
                 fallback_extractor,
@@ -271,6 +274,19 @@ def orchestrate_extraction(
 
         primary_extractor = extractor
         if primary_extractor == ExtractorUsed.GROBID.value and not grobid_available:
+            if fallback_extractor == ExtractorUsed.GROBID.value:
+                error_text = f"GROBID unavailable and no non-GROBID extractor configured: {grobid_unavailable_reason}"
+                active_logger.error("Extractor '%s' failed for %s: %s", primary_extractor, chunk.name, error_text)
+                results.append(
+                    ExtractionResult(
+                        chunk_number=chunk_number,
+                        success=False,
+                        extractor=None,
+                        output_path=None,
+                        error=error_text,
+                    )
+                )
+                continue
             primary_extractor = fallback_extractor
 
         primary_result, primary_error = _run_single_extractor(
@@ -292,6 +308,19 @@ def orchestrate_extraction(
                 chunk.name,
                 primary_error,
             )
+            if fallback_extractor == ExtractorUsed.GROBID.value and not grobid_available:
+                error_text = f"GROBID unavailable for fallback extraction: {grobid_unavailable_reason}"
+                active_logger.error("Fallback extractor '%s' failed for %s: %s", fallback_extractor, chunk.name, error_text)
+                results.append(
+                    ExtractionResult(
+                        chunk_number=chunk_number,
+                        success=False,
+                        extractor=None,
+                        output_path=None,
+                        error=error_text,
+                    )
+                )
+                continue
             fallback_result, fallback_error = _run_single_extractor(
                 fallback_extractor,
                 chunk,

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 import logging
 from pathlib import Path
+import re
 import time
 
 from pdfminer.high_level import extract_text as pdfminer_extract_text
@@ -18,6 +21,8 @@ _DEFAULT_GROBID_POLL_INTERVAL_SECONDS = 2
 _DEFAULT_503_RETRIES = 3
 _DEFAULT_503_BACKOFF_BASE_SECONDS = 5
 _MAX_ERROR_BODY_EXCERPT = 300
+_VALID_EXTRACTORS = {"grobid", "pdfminer"}
+_CHUNK_STEM_PATTERN = re.compile(r"^chunk-(\d+)$")
 
 
 class GrobidError(ValueError):
@@ -26,6 +31,20 @@ class GrobidError(ValueError):
 
 class PdfMinerError(ValueError):
     """Raised when pdfminer fallback extraction fails."""
+
+
+class ExtractorUsed(str, Enum):
+    GROBID = "grobid"
+    PDFMINER = "pdfminer"
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    chunk_number: int
+    success: bool
+    extractor: ExtractorUsed | None
+    output_path: Path | None
+    error: str | None
 
 
 def wait_for_grobid(
@@ -201,6 +220,114 @@ def extract_pdfminer_chunk(
     return output_path
 
 
+def orchestrate_extraction(
+    chunk_paths: list[Path] | tuple[Path, ...],
+    extracted_dir: Path,
+    *,
+    extractor: str = ExtractorUsed.GROBID.value,
+    fallback_extractor: str = ExtractorUsed.PDFMINER.value,
+    grobid_url: str = "http://localhost:8070",
+    logger: logging.Logger | None = None,
+) -> list[ExtractionResult]:
+    """Run extraction for each chunk with fallback and per-chunk result tracking."""
+
+    _validate_extractor_name(extractor, "extractor")
+    _validate_extractor_name(fallback_extractor, "fallback_extractor")
+
+    active_logger = logger or get_logger()
+    output_root = Path(extracted_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    grobid_available = True
+    if extractor == ExtractorUsed.GROBID.value:
+        try:
+            wait_for_grobid(grobid_url, logger=active_logger)
+        except GrobidError as exc:
+            grobid_available = False
+            active_logger.warning(
+                "GROBID unavailable; using fallback extractor '%s' for all chunks: %s",
+                fallback_extractor,
+                exc,
+            )
+
+    results: list[ExtractionResult] = []
+
+    for chunk_path in chunk_paths:
+        chunk = Path(chunk_path)
+        chunk_number = _chunk_number_from_path(chunk)
+
+        primary_extractor = extractor
+        if primary_extractor == ExtractorUsed.GROBID.value and not grobid_available:
+            primary_extractor = fallback_extractor
+
+        primary_result, primary_error = _run_single_extractor(
+            primary_extractor,
+            chunk,
+            output_root,
+            chunk_number,
+            grobid_url,
+            active_logger,
+        )
+        if primary_result is not None:
+            results.append(primary_result)
+            continue
+
+        if primary_extractor != fallback_extractor:
+            active_logger.warning(
+                "Primary extractor '%s' failed for %s: %s",
+                primary_extractor,
+                chunk.name,
+                primary_error,
+            )
+            fallback_result, fallback_error = _run_single_extractor(
+                fallback_extractor,
+                chunk,
+                output_root,
+                chunk_number,
+                grobid_url,
+                active_logger,
+            )
+            if fallback_result is not None:
+                results.append(fallback_result)
+                continue
+            error_text = str(fallback_error)
+            active_logger.error("Fallback extractor '%s' failed for %s: %s", fallback_extractor, chunk.name, error_text)
+            results.append(
+                ExtractionResult(
+                    chunk_number=chunk_number,
+                    success=False,
+                    extractor=None,
+                    output_path=None,
+                    error=error_text,
+                )
+            )
+            continue
+
+        error_text = str(primary_error)
+        active_logger.error("Extractor '%s' failed for %s: %s", primary_extractor, chunk.name, error_text)
+        results.append(
+            ExtractionResult(
+                chunk_number=chunk_number,
+                success=False,
+                extractor=None,
+                output_path=None,
+                error=error_text,
+            )
+        )
+
+    grobid_successes = sum(1 for result in results if result.extractor == ExtractorUsed.GROBID and result.success)
+    pdfminer_successes = sum(1 for result in results if result.extractor == ExtractorUsed.PDFMINER and result.success)
+    failures = sum(1 for result in results if not result.success)
+    active_logger.info(
+        "Extraction summary: %s succeeded (grobid), %s succeeded (pdfminer), %s failed",
+        grobid_successes,
+        pdfminer_successes,
+        failures,
+    )
+
+    return results
+
+
 def _body_excerpt(text: str, max_chars: int = _MAX_ERROR_BODY_EXCERPT) -> str:
     # Stream-normalize whitespace to avoid allocating all tokens for large bodies.
     normalized_chars: list[str] = []
@@ -240,3 +367,65 @@ def _resolve_logger(
     if logger is None:
         return get_chunk_logger(chunk_number)
     return ChunkAdapter(logger, {"chunk": chunk_number})
+
+
+def _validate_extractor_name(value: str, field_name: str) -> None:
+    if value not in _VALID_EXTRACTORS:
+        raise ValueError(f"{field_name} must be one of: {sorted(_VALID_EXTRACTORS)}")
+
+
+def _chunk_number_from_path(path: Path) -> int:
+    match = _CHUNK_STEM_PATTERN.match(path.stem)
+    if not match:
+        raise ValueError(f"Chunk filename must match 'chunk-NNNN.pdf', got: {path.name}")
+    return int(match.group(1))
+
+
+def _run_single_extractor(
+    extractor_name: str,
+    chunk_path: Path,
+    extracted_dir: Path,
+    chunk_number: int,
+    grobid_url: str,
+    logger: logging.Logger,
+) -> tuple[ExtractionResult | None, Exception | None]:
+    try:
+        if extractor_name == ExtractorUsed.GROBID.value:
+            output_path = extracted_dir / f"chunk-{chunk_number:04d}.xml"
+            final_path = extract_grobid_chunk(
+                chunk_path,
+                output_path,
+                grobid_url,
+                logger=logger,
+                chunk_number=chunk_number,
+            )
+            return (
+                ExtractionResult(
+                    chunk_number=chunk_number,
+                    success=True,
+                    extractor=ExtractorUsed.GROBID,
+                    output_path=final_path,
+                    error=None,
+                ),
+                None,
+            )
+
+        output_path = extracted_dir / f"chunk-{chunk_number:04d}.txt"
+        final_path = extract_pdfminer_chunk(
+            chunk_path,
+            output_path,
+            logger=logger,
+            chunk_number=chunk_number,
+        )
+        return (
+            ExtractionResult(
+                chunk_number=chunk_number,
+                success=True,
+                extractor=ExtractorUsed.PDFMINER,
+                output_path=final_path,
+                error=None,
+            ),
+            None,
+        )
+    except (GrobidError, PdfMinerError, ValueError) as exc:
+        return None, exc

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -22,7 +22,7 @@ _DEFAULT_503_RETRIES = 3
 _DEFAULT_503_BACKOFF_BASE_SECONDS = 5
 _MAX_ERROR_BODY_EXCERPT = 300
 _VALID_EXTRACTORS = {"grobid", "pdfminer"}
-_CHUNK_STEM_PATTERN = re.compile(r"^chunk-(\d+)$")
+_CHUNK_STEM_PATTERN = re.compile(r"^chunk-(\d{4})$")
 
 LogLike = logging.Logger | logging.LoggerAdapter
 

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -475,5 +475,5 @@ def _run_single_extractor(
             ),
             None,
         )
-    except (GrobidError, PdfMinerError, ValueError) as exc:
+    except (GrobidError, PdfMinerError, ValueError, OSError, RuntimeError) as exc:
         return None, exc

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -252,9 +252,22 @@ def orchestrate_extraction(
 
     results: list[ExtractionResult] = []
 
-    for chunk_path in chunk_paths:
+    for index, chunk_path in enumerate(chunk_paths, start=1):
         chunk = Path(chunk_path)
-        chunk_number = _chunk_number_from_path(chunk)
+        try:
+            chunk_number = _chunk_number_from_path(chunk)
+        except ValueError as exc:
+            active_logger.error("Invalid chunk filename for extraction: %s: %s", chunk.name, exc)
+            results.append(
+                ExtractionResult(
+                    chunk_number=index,
+                    success=False,
+                    extractor=None,
+                    output_path=None,
+                    error=str(exc),
+                )
+            )
+            continue
 
         primary_extractor = extractor
         if primary_extractor == ExtractorUsed.GROBID.value and not grobid_available:

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -24,6 +24,8 @@ _MAX_ERROR_BODY_EXCERPT = 300
 _VALID_EXTRACTORS = {"grobid", "pdfminer"}
 _CHUNK_STEM_PATTERN = re.compile(r"^chunk-(\d+)$")
 
+LogLike = logging.Logger | logging.LoggerAdapter
+
 
 class GrobidError(ValueError):
     """Raised when GROBID health checks or extraction requests fail."""
@@ -54,7 +56,7 @@ def wait_for_grobid(
     poll_interval: int = _DEFAULT_GROBID_POLL_INTERVAL_SECONDS,
     request_timeout: int = 5,
     session: requests.Session | None = None,
-    logger: logging.Logger | None = None,
+    logger: LogLike | None = None,
 ) -> None:
     """Poll GROBID /api/isalive until ready or timeout."""
 
@@ -95,7 +97,7 @@ def extract_grobid_chunk(
     retries_on_503: int = _DEFAULT_503_RETRIES,
     backoff_base_seconds: int = _DEFAULT_503_BACKOFF_BASE_SECONDS,
     session: requests.Session | None = None,
-    logger: logging.Logger | None = None,
+    logger: LogLike | None = None,
     chunk_number: int | None = None,
 ) -> Path:
     """Submit a chunk PDF to GROBID and write TEI XML output."""
@@ -187,7 +189,7 @@ def extract_pdfminer_chunk(
     chunk_pdf: Path,
     output_text: Path,
     *,
-    logger: logging.Logger | None = None,
+    logger: LogLike | None = None,
     chunk_number: int | None = None,
 ) -> Path:
     """Extract plain text from a chunk PDF using pdfminer and write UTF-8 text output."""
@@ -227,7 +229,7 @@ def orchestrate_extraction(
     extractor: str = ExtractorUsed.GROBID.value,
     fallback_extractor: str = ExtractorUsed.PDFMINER.value,
     grobid_url: str = "http://localhost:8070",
-    logger: logging.Logger | None = None,
+    logger: LogLike | None = None,
 ) -> list[ExtractionResult]:
     """Run extraction for each chunk with fallback and per-chunk result tracking."""
 
@@ -401,9 +403,9 @@ def _body_excerpt(text: str, max_chars: int = _MAX_ERROR_BODY_EXCERPT) -> str:
 
 
 def _resolve_logger(
-    logger: logging.Logger | None,
+    logger: LogLike | None,
     chunk_number: int | None,
-) -> logging.Logger | ChunkAdapter:
+) -> LogLike | ChunkAdapter:
     if chunk_number is None:
         return logger or get_logger()
     if logger is None:
@@ -429,7 +431,7 @@ def _run_single_extractor(
     extracted_dir: Path,
     chunk_number: int,
     grobid_url: str,
-    logger: logging.Logger,
+    logger: LogLike,
 ) -> tuple[ExtractionResult | None, Exception | None]:
     try:
         if extractor_name == ExtractorUsed.GROBID.value:

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -422,7 +422,10 @@ def _chunk_number_from_path(path: Path) -> int:
     match = _CHUNK_STEM_PATTERN.match(path.stem)
     if not match:
         raise ValueError(f"Chunk filename must match 'chunk-NNNN.pdf', got: {path.name}")
-    return int(match.group(1))
+    chunk_number = int(match.group(1))
+    if chunk_number < 1:
+        raise ValueError(f"Chunk filename must use chunk number >= 0001, got: {path.name}")
+    return chunk_number
 
 
 def _run_single_extractor(

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -420,6 +420,8 @@ def _validate_extractor_name(value: str, field_name: str) -> None:
 
 
 def _chunk_number_from_path(path: Path) -> int:
+    if path.suffix.lower() != ".pdf":
+        raise ValueError(f"Chunk filename must use .pdf extension, got: {path.name}")
     match = _CHUNK_STEM_PATTERN.match(path.stem)
     if not match:
         raise ValueError(f"Chunk filename must match 'chunk-NNNN.pdf', got: {path.name}")

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -257,7 +257,7 @@ def orchestrate_extraction(
 
     results: list[ExtractionResult] = []
 
-    for index, chunk_path in enumerate(chunk_paths, start=1):
+    for chunk_path in chunk_paths:
         chunk = Path(chunk_path)
         try:
             chunk_number = _chunk_number_from_path(chunk)

--- a/docdown/stages/extract.py
+++ b/docdown/stages/extract.py
@@ -265,7 +265,7 @@ def orchestrate_extraction(
             active_logger.error("Invalid chunk filename for extraction: %s: %s", chunk.name, exc)
             results.append(
                 ExtractionResult(
-                    chunk_number=index,
+                    chunk_number=0,
                     success=False,
                     extractor=None,
                     output_path=None,

--- a/docs/plan/task-3.3-extraction-orchestration.md
+++ b/docs/plan/task-3.3-extraction-orchestration.md
@@ -11,14 +11,18 @@ Implement the orchestration layer that runs the primary extractor, falls back wh
 
 ## Acceptance Criteria
 
-- [ ] For each chunk: try primary extractor → on failure, try fallback → on failure, mark as failed.
-- [ ] Extractor choice is driven by config (`extractor`, `fallback_extractor`).
-- [ ] Per-chunk result is tracked: `success (grobid)`, `success (pdfminer)`, or `failed`.
-- [ ] Failed chunks do not block processing of other chunks.
-- [ ] If GROBID is entirely unreachable, all chunks fall back to pdfminer without per-chunk retries.
-- [ ] Extraction results are returned as a list for downstream stages to consume.
-- [ ] Summary logged: N succeeded (grobid), M succeeded (pdfminer), K failed.
-- [ ] Unit tests cover: all-succeed, partial-failure, full-GROBID-down, all-fail scenarios.
+- [x] For each chunk: try primary extractor → on failure, try fallback → on failure, mark as failed.
+- [x] Extractor choice is driven by config (`extractor`, `fallback_extractor`).
+- [x] Per-chunk result is tracked: `success (grobid)`, `success (pdfminer)`, or `failed`.
+- [x] Failed chunks do not block processing of other chunks.
+- [x] If GROBID is entirely unreachable, all chunks fall back to pdfminer without per-chunk retries.
+- [x] Extraction results are returned as a list for downstream stages to consume.
+- [x] Summary logged: N succeeded (grobid), M succeeded (pdfminer), K failed.
+- [x] Unit tests cover: all-succeed, partial-failure, full-GROBID-down, all-fail scenarios.
+
+Implemented in:
+- `docdown/stages/extract.py`
+- `tests/test_extract.py`
 
 ## Implementation Notes
 
@@ -60,6 +64,54 @@ def extract_chunk(chunk_path, chunk_num, config, workdir):
     except ExtractionError as e:
         log.error(f"[chunk-{chunk_num:04d}] Fallback extractor failed: {e}")
         return ExtractionResult(chunk_num, False, None, None, str(e))
+```
+
+### Artifact Class Diagram
+
+```mermaid
+classDiagram
+    class ExtractorUsed {
+        <<enum>>
+        GROBID
+        PDFMINER
+    }
+
+    class ExtractionResult {
+        +chunk_number: int
+        +success: bool
+        +extractor: ExtractorUsed|None
+        +output_path: Path|None
+        +error: str|None
+    }
+
+    class ExtractStageModule {
+        <<module: docdown/stages/extract.py>>
+        +orchestrate_extraction(chunk_paths, extracted_dir, *, extractor, fallback_extractor, grobid_url, logger) list~ExtractionResult~
+        -_run_single_extractor(extractor_name, chunk_path, extracted_dir, chunk_number, grobid_url, logger)
+    }
+
+    class GrobidExtractor {
+        +wait_for_grobid(...)
+        +extract_grobid_chunk(...)
+    }
+
+    class PdfMinerExtractor {
+        +extract_pdfminer_chunk(...)
+    }
+
+    class TestExtract {
+        <<tests/test_extract.py>>
+        +all-succeed orchestration test
+        +partial-fallback test
+        +full-GROBID-down test
+        +all-fail test
+    }
+
+    ExtractStageModule --> ExtractionResult : returns
+    ExtractionResult --> ExtractorUsed : uses
+    ExtractStageModule ..> GrobidExtractor : primary/fallback invocation
+    ExtractStageModule ..> PdfMinerExtractor : primary/fallback invocation
+    TestExtract ..> ExtractStageModule : verifies orchestration behavior
 ```
 
 ## References

--- a/docs/plan/task-3.3-extraction-orchestration.md
+++ b/docs/plan/task-3.3-extraction-orchestration.md
@@ -15,7 +15,7 @@ Implement the orchestration layer that runs the primary extractor, falls back wh
 - [x] Extractor choice is driven by config (`extractor`, `fallback_extractor`).
 - [x] Per-chunk result is tracked: `success (grobid)`, `success (pdfminer)`, or `failed`.
 - [x] Failed chunks do not block processing of other chunks.
-- [x] If GROBID is entirely unreachable, all chunks fall back to pdfminer without per-chunk retries.
+- [x] If GROBID is entirely unreachable, orchestration skips GROBID attempts and uses the configured fallback extractor without per-chunk GROBID retries (or records clear failures when fallback is also GROBID).
 - [x] Extraction results are returned as a list for downstream stages to consume.
 - [x] Summary logged: N succeeded (grobid), M succeeded (pdfminer), K failed.
 - [x] Unit tests cover: all-succeed, partial-failure, full-GROBID-down, all-fail scenarios.

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -355,6 +355,70 @@ def test_orchestrate_extraction_when_grobid_down_skips_per_chunk_grobid(tmp_path
     assert all(result.success for result in results)
 
 
+def test_orchestrate_extraction_when_grobid_down_and_used_as_fallback_skips_calls(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr(
+        "docdown.stages.extract.wait_for_grobid",
+        lambda *args, **kwargs: (_ for _ in ()).throw(GrobidError("unreachable")),
+    )
+    monkeypatch.setattr(
+        "docdown.stages.extract.extract_pdfminer_chunk",
+        lambda *args, **kwargs: (_ for _ in ()).throw(PdfMinerError("primary failed")),
+    )
+
+    grobid_calls = {"count": 0}
+
+    def _never_called(*args, **kwargs):
+        grobid_calls["count"] += 1
+        raise AssertionError("extract_grobid_chunk should not be called when GROBID is down")
+
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", _never_called)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="pdfminer",
+        fallback_extractor="grobid",
+    )
+
+    assert grobid_calls["count"] == 0
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "GROBID unavailable for fallback extraction" in (results[0].error or "")
+
+
+def test_orchestrate_extraction_when_both_extractors_are_grobid_and_down_fails_without_calls(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr(
+        "docdown.stages.extract.wait_for_grobid",
+        lambda *args, **kwargs: (_ for _ in ()).throw(GrobidError("unreachable")),
+    )
+
+    grobid_calls = {"count": 0}
+
+    def _never_called(*args, **kwargs):
+        grobid_calls["count"] += 1
+        raise AssertionError("extract_grobid_chunk should not be called when GROBID is down")
+
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", _never_called)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="grobid",
+    )
+
+    assert grobid_calls["count"] == 0
+    assert len(results) == 2
+    assert all(not result.success for result in results)
+    assert all("no non-GROBID extractor configured" in (result.error or "") for result in results)
+
+
 def test_orchestrate_extraction_all_fail_returns_failed_results(tmp_path, monkeypatch):
     chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
     out_dir = tmp_path / "extracted"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -470,6 +470,26 @@ def test_orchestrate_extraction_invalid_chunk_name_does_not_block_others(tmp_pat
     assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
 
 
+def test_orchestrate_extraction_rejects_non_padded_chunk_number(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-1.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", lambda chunk, output, *args, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert len(results) == 2
+    assert results[0].success is False
+    assert "chunk-NNNN.pdf" in (results[0].error or "")
+    assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
+
+
 def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):
     chunk = tmp_path / "chunk-0001.pdf"
     output = tmp_path / "chunk-0001.txt"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -539,6 +539,27 @@ def test_orchestrate_extraction_rejects_chunk_zero_filename(tmp_path, monkeypatc
     assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
 
 
+def test_orchestrate_extraction_rejects_non_pdf_chunk_extension(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.txt", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", lambda chunk, output, *args, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert len(results) == 2
+    assert results[0].success is False
+    assert results[0].chunk_number == 0
+    assert "must use .pdf extension" in (results[0].error or "")
+    assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
+
+
 def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):
     chunk = tmp_path / "chunk-0001.pdf"
     output = tmp_path / "chunk-0001.txt"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -447,6 +447,32 @@ def test_orchestrate_extraction_all_fail_returns_failed_results(tmp_path, monkey
     assert all(result.error == "pdfminer failed" for result in results)
 
 
+def test_orchestrate_extraction_continues_after_primary_oserror(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+
+    def _fake_grobid(chunk, output, grobid_url, **kwargs):
+        if chunk.name == "chunk-0001.pdf":
+            raise OSError("disk write failed")
+        return output
+
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", _fake_grobid)
+    monkeypatch.setattr("docdown.stages.extract.extract_pdfminer_chunk", lambda chunk, output, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert len(results) == 2
+    assert results[0] == ExtractionResult(1, True, ExtractorUsed.PDFMINER, out_dir / "chunk-0001.txt", None)
+    assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
+
+
 def test_orchestrate_extraction_invalid_chunk_name_does_not_block_others(tmp_path, monkeypatch):
     chunks = [tmp_path / "bad-name.pdf", tmp_path / "chunk-0002.pdf"]
     out_dir = tmp_path / "extracted"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -9,10 +9,13 @@ import pytest
 import requests
 
 from docdown.stages.extract import (
+    ExtractorUsed,
+    ExtractionResult,
     GrobidError,
     PdfMinerError,
     extract_grobid_chunk,
     extract_pdfminer_chunk,
+    orchestrate_extraction,
     wait_for_grobid,
 )
 
@@ -269,6 +272,115 @@ def test_extract_pdfminer_chunk_rejects_missing_chunk_file(tmp_path):
 
     with pytest.raises(PdfMinerError, match=r"Chunk PDF not found: .*chunk-0001\.pdf"):
         extract_pdfminer_chunk(missing_chunk, output)
+
+
+def test_orchestrate_extraction_all_succeed_with_grobid(tmp_path, monkeypatch, caplog):
+    chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", lambda chunk, output, *args, **kwargs: output)
+
+    test_logger = logging.getLogger("tests.extract.orchestration")
+    with caplog.at_level(logging.INFO, logger="tests.extract.orchestration"):
+        results = orchestrate_extraction(
+            chunks,
+            out_dir,
+            extractor="grobid",
+            fallback_extractor="pdfminer",
+            logger=test_logger,
+        )
+
+    assert results == [
+        ExtractionResult(1, True, ExtractorUsed.GROBID, out_dir / "chunk-0001.xml", None),
+        ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None),
+    ]
+    assert "Extraction summary: 2 succeeded (grobid), 0 succeeded (pdfminer), 0 failed" in caplog.text
+
+
+def test_orchestrate_extraction_partial_failure_falls_back_per_chunk(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+
+    def _fake_grobid(chunk, output, grobid_url, **kwargs):
+        if chunk.name == "chunk-0001.pdf":
+            raise GrobidError("primary failed")
+        return output
+
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", _fake_grobid)
+    monkeypatch.setattr("docdown.stages.extract.extract_pdfminer_chunk", lambda chunk, output, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert [result.extractor for result in results] == [ExtractorUsed.PDFMINER, ExtractorUsed.GROBID]
+    assert all(result.success for result in results)
+    assert results[0].output_path == out_dir / "chunk-0001.txt"
+    assert results[1].output_path == out_dir / "chunk-0002.xml"
+
+
+def test_orchestrate_extraction_when_grobid_down_skips_per_chunk_grobid(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr(
+        "docdown.stages.extract.wait_for_grobid",
+        lambda *args, **kwargs: (_ for _ in ()).throw(GrobidError("unreachable")),
+    )
+
+    grobid_calls = {"count": 0}
+
+    def _never_called(*args, **kwargs):
+        grobid_calls["count"] += 1
+        raise AssertionError("extract_grobid_chunk should not be called when GROBID is down")
+
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", _never_called)
+    monkeypatch.setattr("docdown.stages.extract.extract_pdfminer_chunk", lambda chunk, output, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert grobid_calls["count"] == 0
+    assert [result.extractor for result in results] == [ExtractorUsed.PDFMINER, ExtractorUsed.PDFMINER]
+    assert all(result.success for result in results)
+
+
+def test_orchestrate_extraction_all_fail_returns_failed_results(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0001.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "docdown.stages.extract.extract_grobid_chunk",
+        lambda *args, **kwargs: (_ for _ in ()).throw(GrobidError("grobid failed")),
+    )
+    monkeypatch.setattr(
+        "docdown.stages.extract.extract_pdfminer_chunk",
+        lambda *args, **kwargs: (_ for _ in ()).throw(PdfMinerError("pdfminer failed")),
+    )
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert len(results) == 2
+    assert all(not result.success for result in results)
+    assert all(result.extractor is None for result in results)
+    assert all(result.output_path is None for result in results)
+    assert all(result.error == "pdfminer failed" for result in results)
 
 
 def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -383,6 +383,29 @@ def test_orchestrate_extraction_all_fail_returns_failed_results(tmp_path, monkey
     assert all(result.error == "pdfminer failed" for result in results)
 
 
+def test_orchestrate_extraction_invalid_chunk_name_does_not_block_others(tmp_path, monkeypatch):
+    chunks = [tmp_path / "bad-name.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", lambda chunk, output, *args, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert len(results) == 2
+    assert results[0].success is False
+    assert results[0].extractor is None
+    assert results[0].output_path is None
+    assert "Chunk filename must match" in (results[0].error or "")
+
+    assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
+
+
 def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):
     chunk = tmp_path / "chunk-0001.pdf"
     output = tmp_path / "chunk-0001.txt"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -463,6 +463,7 @@ def test_orchestrate_extraction_invalid_chunk_name_does_not_block_others(tmp_pat
 
     assert len(results) == 2
     assert results[0].success is False
+    assert results[0].chunk_number == 0
     assert results[0].extractor is None
     assert results[0].output_path is None
     assert "Chunk filename must match" in (results[0].error or "")
@@ -486,6 +487,7 @@ def test_orchestrate_extraction_rejects_non_padded_chunk_number(tmp_path, monkey
 
     assert len(results) == 2
     assert results[0].success is False
+    assert results[0].chunk_number == 0
     assert "chunk-NNNN.pdf" in (results[0].error or "")
     assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -492,6 +492,27 @@ def test_orchestrate_extraction_rejects_non_padded_chunk_number(tmp_path, monkey
     assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
 
 
+def test_orchestrate_extraction_rejects_chunk_zero_filename(tmp_path, monkeypatch):
+    chunks = [tmp_path / "chunk-0000.pdf", tmp_path / "chunk-0002.pdf"]
+    out_dir = tmp_path / "extracted"
+
+    monkeypatch.setattr("docdown.stages.extract.wait_for_grobid", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.stages.extract.extract_grobid_chunk", lambda chunk, output, *args, **kwargs: output)
+
+    results = orchestrate_extraction(
+        chunks,
+        out_dir,
+        extractor="grobid",
+        fallback_extractor="pdfminer",
+    )
+
+    assert len(results) == 2
+    assert results[0].success is False
+    assert results[0].chunk_number == 0
+    assert "chunk number >= 0001" in (results[0].error or "")
+    assert results[1] == ExtractionResult(2, True, ExtractorUsed.GROBID, out_dir / "chunk-0002.xml", None)
+
+
 def test_extract_pdfminer_chunk_rejects_empty_output(tmp_path, monkeypatch):
     chunk = tmp_path / "chunk-0001.pdf"
     output = tmp_path / "chunk-0001.txt"


### PR DESCRIPTION
## Summary
- add extraction orchestration API in `docdown/stages/extract.py`
- implement per-chunk primary/fallback flow with `ExtractionResult` tracking and `ExtractorUsed` enum
- add global GROBID availability gate: when unreachable, route all chunks directly to fallback
- keep chunk-level failure isolation so failed chunks do not block others
- add extraction summary logging (grobid/pdfminer/failed counts)
- add orchestration unit tests for all-succeed, partial-failure, full-grobid-down, and all-fail scenarios
- update Task 3.3 checklist and artifact diagram

## Testing
- `pytest tests/test_extract.py -q`
- `pytest -q`