### PR TITLE
Task 4.1: Wire extraction pipeline and add Pandoc conversion

### DIFF
--- a/docdown.yaml
+++ b/docdown.yaml
@@ -3,7 +3,7 @@
 workdir: ./output
 chunk_size: 50
 parallel_workers: 4
-extractor: grobid
+extractor: pdfminer
 grobid_url: http://localhost:8070
 fallback_extractor: pdfminer
 table_extraction: true

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -1,5 +1,7 @@
 """CLI entry point for DocDown."""
 
+from pathlib import Path
+
 import click
 
 from docdown.config import ConfigError, load_config
@@ -78,7 +80,7 @@ def main(
     }
 
     try:
-        cfg = load_config(config_path=config, cli_overrides=cli_overrides)
+        cfg = load_config(config_path=_resolve_config_path(config), cli_overrides=cli_overrides)
     except ConfigError as exc:
         raise click.ClickException(str(exc)) from exc
 
@@ -171,4 +173,11 @@ def main(
 def _version():
     from docdown import __version__
     return __version__
+
+
+def _resolve_config_path(config_option: str | None) -> Path | None:
+    if config_option is not None:
+        return Path(config_option)
+    default_config = Path("docdown.yaml")
+    return default_config if default_config.exists() else None
 

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -3,7 +3,9 @@
 import click
 
 from docdown.config import ConfigError, load_config
-from docdown.stages.split import PdfValidationError, validate_pdf
+from docdown.stages.convert import PandocError, convert_to_markdown, ensure_pandoc_available
+from docdown.stages.extract import orchestrate_extraction
+from docdown.stages.split import PdfSplitError, PdfValidationError, split_pdf, validate_pdf
 from docdown.utils.logging import configure_logging
 from docdown.workdir import WorkDir, WorkDirError
 
@@ -111,6 +113,59 @@ def main(
         raise click.ClickException(str(exc)) from exc
 
     logger.info("PDF ready for splitting: pages=%s size_bytes=%s", validation.page_count, validation.file_size_bytes)
+
+    try:
+        split_result = split_pdf(
+            staged_input,
+            work_dir.chunks_dir,
+            cfg.chunk_size,
+            validation.page_count,
+            logger=logger,
+        )
+    except PdfSplitError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    logger.info("Split complete: %s chunks", split_result.chunk_count)
+
+    extraction_results = orchestrate_extraction(
+        split_result.chunk_paths,
+        work_dir.extracted_dir,
+        extractor=cfg.extractor,
+        fallback_extractor=cfg.fallback_extractor,
+        grobid_url=cfg.grobid_url,
+        logger=logger,
+    )
+
+    successful_extractions = [
+        result for result in extraction_results if result.success and result.output_path is not None
+    ]
+    if not successful_extractions:
+        raise click.ClickException("Extraction failed for all chunks; no conversion input available.")
+
+    try:
+        ensure_pandoc_available(logger=logger)
+    except PandocError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    converted_chunks = 0
+    for result in successful_extractions:
+        markdown_path = work_dir.markdown(result.chunk_number)
+        try:
+            convert_to_markdown(
+                result.output_path,
+                markdown_path,
+                logger=logger,
+                chunk_number=result.chunk_number,
+            )
+        except PandocError as exc:
+            logger.error("Pandoc conversion failed for chunk-%04d: %s", result.chunk_number, exc)
+            continue
+        converted_chunks += 1
+
+    if converted_chunks == 0:
+        raise click.ClickException("Pandoc conversion failed for all extracted chunks.")
+
+    logger.info("Conversion summary: %s converted, %s extraction successes skipped/failed", converted_chunks, len(successful_extractions) - converted_chunks)
 
 
 def _version():

--- a/docdown/stages/convert.py
+++ b/docdown/stages/convert.py
@@ -1,1 +1,104 @@
-"""Stage 3 — Markdown conversion (placeholder)."""
+"""Stage 3 — Markdown conversion with Pandoc."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import subprocess
+import time
+
+from docdown.utils.logging import get_logger, log_tool_command
+
+
+_FORMAT_BY_SUFFIX = {
+	".xml": "tei",
+	".txt": "plain",
+}
+
+LogLike = logging.Logger | logging.LoggerAdapter
+
+
+class PandocError(ValueError):
+	"""Raised when Pandoc is unavailable or conversion fails."""
+
+
+def ensure_pandoc_available(*, logger: LogLike | None = None) -> None:
+	"""Verify Pandoc is installed and executable."""
+
+	active_logger = logger or get_logger()
+	command = ["pandoc", "--version"]
+	log_tool_command(command)
+	try:
+		result = subprocess.run(command, capture_output=True, text=True, check=False)
+	except OSError as exc:
+		raise PandocError(
+			"Pandoc is not available on PATH. Install Pandoc to enable Markdown conversion."
+		) from exc
+
+	if result.returncode != 0:
+		diagnostics = _combined_output(result)
+		raise PandocError(f"Pandoc availability check failed: {diagnostics}")
+
+	first_line = next((line for line in result.stdout.splitlines() if line.strip()), "pandoc")
+	active_logger.info("Pandoc available: %s", first_line)
+
+
+def convert_to_markdown(
+	input_path: Path,
+	output_path: Path,
+	*,
+	logger: LogLike | None = None,
+	chunk_number: int | None = None,
+) -> Path:
+	"""Convert extracted XML/TXT artifact to GFM Markdown via Pandoc."""
+
+	source = Path(input_path)
+	target = Path(output_path)
+	active_logger = logger or get_logger()
+
+	if not source.exists() or not source.is_file():
+		raise PandocError(f"Conversion input not found: {source}")
+
+	source_format = _input_format_for_path(source)
+
+	target.parent.mkdir(parents=True, exist_ok=True)
+	command = [
+		"pandoc",
+		str(source),
+		"-f",
+		source_format,
+		"-t",
+		"gfm",
+		"--wrap=none",
+		"-o",
+		str(target),
+	]
+	log_tool_command(command, chunk_number=chunk_number)
+
+	started = time.monotonic()
+	try:
+		result = subprocess.run(command, capture_output=True, text=True, check=False)
+	except OSError as exc:
+		raise PandocError(f"Failed to execute pandoc for {source.name}: {exc}") from exc
+
+	if result.returncode != 0:
+		diagnostics = _combined_output(result)
+		raise PandocError(f"Pandoc conversion failed for {source.name}: {diagnostics}")
+
+	elapsed = time.monotonic() - started
+	active_logger.info("Pandoc conversion complete for %s in %.2fs", source.name, elapsed)
+	return target
+
+
+def _input_format_for_path(path: Path) -> str:
+	suffix = path.suffix.lower()
+	if suffix not in _FORMAT_BY_SUFFIX:
+		raise PandocError(
+			f"Unsupported conversion input extension '{path.suffix}' for {path.name}; expected .xml or .txt"
+		)
+	return _FORMAT_BY_SUFFIX[suffix]
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+	combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+	return combined if combined else "<no diagnostics>"

--- a/docdown/stages/convert.py
+++ b/docdown/stages/convert.py
@@ -11,95 +11,95 @@ from docdown.utils.logging import get_logger, log_tool_command
 
 
 _FORMAT_BY_SUFFIX = {
-	".xml": "tei",
-	# Pandoc does not support a generic "plain" input reader; treat raw text as markdown.
-	".txt": "markdown",
+    ".xml": "tei",
+    # Pandoc does not support a generic "plain" input reader; treat raw text as markdown.
+    ".txt": "markdown",
 }
 
 LogLike = logging.Logger | logging.LoggerAdapter
 
 
 class PandocError(ValueError):
-	"""Raised when Pandoc is unavailable or conversion fails."""
+    """Raised when Pandoc is unavailable or conversion fails."""
 
 
 def ensure_pandoc_available(*, logger: LogLike | None = None) -> None:
-	"""Verify Pandoc is installed and executable."""
+    """Verify Pandoc is installed and executable."""
 
-	active_logger = logger or get_logger()
-	command = ["pandoc", "--version"]
-	log_tool_command(command)
-	try:
-		result = subprocess.run(command, capture_output=True, text=True, check=False)
-	except OSError as exc:
-		raise PandocError(
-			"Pandoc is not available on PATH. Install Pandoc to enable Markdown conversion."
-		) from exc
+    active_logger = logger or get_logger()
+    command = ["pandoc", "--version"]
+    log_tool_command(command)
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise PandocError(
+            "Pandoc is not available on PATH. Install Pandoc to enable Markdown conversion."
+        ) from exc
 
-	if result.returncode != 0:
-		diagnostics = _combined_output(result)
-		raise PandocError(f"Pandoc availability check failed: {diagnostics}")
+    if result.returncode != 0:
+        diagnostics = _combined_output(result)
+        raise PandocError(f"Pandoc availability check failed: {diagnostics}")
 
-	first_line = next((line for line in result.stdout.splitlines() if line.strip()), "pandoc")
-	active_logger.info("Pandoc available: %s", first_line)
+    first_line = next((line for line in result.stdout.splitlines() if line.strip()), "pandoc")
+    active_logger.info("Pandoc available: %s", first_line)
 
 
 def convert_to_markdown(
-	input_path: Path,
-	output_path: Path,
-	*,
-	logger: LogLike | None = None,
-	chunk_number: int | None = None,
+    input_path: Path,
+    output_path: Path,
+    *,
+    logger: LogLike | None = None,
+    chunk_number: int | None = None,
 ) -> Path:
-	"""Convert extracted XML/TXT artifact to GFM Markdown via Pandoc."""
+    """Convert extracted XML/TXT artifact to GFM Markdown via Pandoc."""
 
-	source = Path(input_path)
-	target = Path(output_path)
-	active_logger = logger or get_logger()
+    source = Path(input_path)
+    target = Path(output_path)
+    active_logger = logger or get_logger()
 
-	if not source.exists() or not source.is_file():
-		raise PandocError(f"Conversion input not found: {source}")
+    if not source.exists() or not source.is_file():
+        raise PandocError(f"Conversion input not found: {source}")
 
-	source_format = _input_format_for_path(source)
+    source_format = _input_format_for_path(source)
 
-	target.parent.mkdir(parents=True, exist_ok=True)
-	command = [
-		"pandoc",
-		str(source),
-		"-f",
-		source_format,
-		"-t",
-		"gfm",
-		"--wrap=none",
-		"-o",
-		str(target),
-	]
-	log_tool_command(command, chunk_number=chunk_number)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        "pandoc",
+        str(source),
+        "-f",
+        source_format,
+        "-t",
+        "gfm",
+        "--wrap=none",
+        "-o",
+        str(target),
+    ]
+    log_tool_command(command, chunk_number=chunk_number)
 
-	started = time.monotonic()
-	try:
-		result = subprocess.run(command, capture_output=True, text=True, check=False)
-	except OSError as exc:
-		raise PandocError(f"Failed to execute pandoc for {source.name}: {exc}") from exc
+    started = time.monotonic()
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise PandocError(f"Failed to execute pandoc for {source.name}: {exc}") from exc
 
-	if result.returncode != 0:
-		diagnostics = _combined_output(result)
-		raise PandocError(f"Pandoc conversion failed for {source.name}: {diagnostics}")
+    if result.returncode != 0:
+        diagnostics = _combined_output(result)
+        raise PandocError(f"Pandoc conversion failed for {source.name}: {diagnostics}")
 
-	elapsed = time.monotonic() - started
-	active_logger.info("Pandoc conversion complete for %s in %.2fs", source.name, elapsed)
-	return target
+    elapsed = time.monotonic() - started
+    active_logger.info("Pandoc conversion complete for %s in %.2fs", source.name, elapsed)
+    return target
 
 
 def _input_format_for_path(path: Path) -> str:
-	suffix = path.suffix.lower()
-	if suffix not in _FORMAT_BY_SUFFIX:
-		raise PandocError(
-			f"Unsupported conversion input extension '{path.suffix}' for {path.name}; expected .xml or .txt"
-		)
-	return _FORMAT_BY_SUFFIX[suffix]
+    suffix = path.suffix.lower()
+    if suffix not in _FORMAT_BY_SUFFIX:
+        raise PandocError(
+            f"Unsupported conversion input extension '{path.suffix}' for {path.name}; expected .xml or .txt"
+        )
+    return _FORMAT_BY_SUFFIX[suffix]
 
 
 def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
-	combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
-	return combined if combined else "<no diagnostics>"
+    combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+    return combined if combined else "<no diagnostics>"

--- a/docdown/stages/convert.py
+++ b/docdown/stages/convert.py
@@ -12,7 +12,8 @@ from docdown.utils.logging import get_logger, log_tool_command
 
 _FORMAT_BY_SUFFIX = {
 	".xml": "tei",
-	".txt": "plain",
+	# Pandoc does not support a generic "plain" input reader; treat raw text as markdown.
+	".txt": "markdown",
 }
 
 LogLike = logging.Logger | logging.LoggerAdapter

--- a/docs/docker-wsl-grobid-setup.md
+++ b/docs/docker-wsl-grobid-setup.md
@@ -42,6 +42,47 @@ docker info
 
 If these commands return both Client and Server sections successfully, Docker is ready.
 
+## Troubleshooting
+
+### Error: `WSL2 is not supported ... HCS_E_HYPERV_NOT_INSTALLED`
+
+This means virtualization support is still missing at the host level.
+
+Run in an **Administrator PowerShell** window:
+
+```powershell
+dism /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
+dism /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
+dism /online /enable-feature /featurename:HypervisorPlatform /all /norestart
+bcdedit /set hypervisorlaunchtype auto
+```
+
+Then reboot and verify:
+
+```powershell
+wsl --status
+wsl -l -v
+docker version
+```
+
+If errors persist, enable CPU virtualization in BIOS/UEFI:
+
+- Intel: `VT-x` (and usually `VT-d`)
+- AMD: `SVM` / `AMD-V`
+
+### Error: `0x800f080c` for `Microsoft-Hyper-V-All`
+
+On many Windows Home systems this feature name is unavailable. This is expected.
+
+- Do **not** rely on `Microsoft-Hyper-V-All`.
+- Use `VirtualMachinePlatform`, `Microsoft-Windows-Subsystem-Linux`, and `HypervisorPlatform` instead (commands above).
+
+To see feature names available on your machine:
+
+```powershell
+dism /online /Get-Features /Format:Table | findstr /i "Hyper-V Hypervisor VirtualMachinePlatform Subsystem-Linux"
+```
+
 ## Start GROBID
 
 ```powershell

--- a/docs/docker-wsl-grobid-setup.md
+++ b/docs/docker-wsl-grobid-setup.md
@@ -1,0 +1,63 @@
+# Docker + WSL + GROBID Setup (Windows)
+
+Use this when Docker Desktop installs successfully but Linux containers fail with a `dockerDesktopLinuxEngine` 500 error.
+
+## Symptoms
+
+- `docker --version` works, but:
+- `docker version` fails with server/API errors on `dockerDesktopLinuxEngine`.
+- `wsl --status` fails or only prints help text.
+
+## Fix Steps
+
+Run these in an **Administrator PowerShell** window.
+
+### 1) Install/enable WSL backend
+
+```powershell
+wsl --install --no-distribution
+```
+
+### 2) Reboot Windows
+
+A reboot is required after enabling WSL features.
+
+### 3) Verify WSL
+
+```powershell
+wsl --status
+wsl -l -v
+```
+
+### 4) Start Docker Desktop
+
+Open Docker Desktop and wait until it reports the engine is running.
+
+### 5) Verify Docker server connectivity
+
+```powershell
+docker version
+docker info
+```
+
+If these commands return both Client and Server sections successfully, Docker is ready.
+
+## Start GROBID
+
+```powershell
+docker run -d --name grobid -p 8070:8070 lfoppiano/grobid:0.8.1
+```
+
+## Verify GROBID health
+
+```powershell
+Invoke-WebRequest http://localhost:8070/api/isalive -UseBasicParsing
+```
+
+Expected response body is `true`.
+
+## Optional: run DocDown with GROBID primary
+
+```powershell
+docdown "<input.pdf>" --workdir "./runs/external-smoke-grobid" --extractor grobid --fallback-extractor pdfminer --log-level INFO
+```

--- a/docs/plan/task-4.1-pandoc-conversion.md
+++ b/docs/plan/task-4.1-pandoc-conversion.md
@@ -12,7 +12,7 @@ Convert extracted intermediate files (TEI XML or plain text) into GitHub-Flavore
 
 - [x] TEI XML files (from GROBID) are converted to GFM Markdown via Pandoc.
 - [x] Plain text files (from pdfminer) are converted to GFM Markdown via Pandoc.
-- [x] Input format is selected based on file extension (`.xml` → TEI, `.txt` → plain).
+- [x] Input format is selected based on file extension (`.xml` → TEI, `.txt` → markdown-compatible plain text).
 - [x] `--wrap=none` is used to prevent hard line wrapping.
 - [x] Output is written to `workdir/markdown/chunk-NNNN.md`.
 - [x] Pandoc errors are caught and reported with stderr output.

--- a/docs/plan/task-4.1-pandoc-conversion.md
+++ b/docs/plan/task-4.1-pandoc-conversion.md
@@ -71,7 +71,7 @@ classDiagram
     class PandocTool {
         <<external: pandoc>>
         +pandoc --version
-        +pandoc input -f tei|plain -t gfm --wrap=none -o output
+        +pandoc input -f tei|markdown -t gfm --wrap=none -o output
     }
 
     class TestConvert {

--- a/docs/plan/task-4.1-pandoc-conversion.md
+++ b/docs/plan/task-4.1-pandoc-conversion.md
@@ -10,14 +10,20 @@ Convert extracted intermediate files (TEI XML or plain text) into GitHub-Flavore
 
 ## Acceptance Criteria
 
-- [ ] TEI XML files (from GROBID) are converted to GFM Markdown via Pandoc.
-- [ ] Plain text files (from pdfminer) are converted to GFM Markdown via Pandoc.
-- [ ] Input format is selected based on file extension (`.xml` → TEI, `.txt` → plain).
-- [ ] `--wrap=none` is used to prevent hard line wrapping.
-- [ ] Output is written to `workdir/markdown/chunk-NNNN.md`.
-- [ ] Pandoc errors are caught and reported with stderr output.
-- [ ] Conversion time per chunk is logged.
-- [ ] Unit tests verify correct Pandoc flags for each input format.
+- [x] TEI XML files (from GROBID) are converted to GFM Markdown via Pandoc.
+- [x] Plain text files (from pdfminer) are converted to GFM Markdown via Pandoc.
+- [x] Input format is selected based on file extension (`.xml` → TEI, `.txt` → plain).
+- [x] `--wrap=none` is used to prevent hard line wrapping.
+- [x] Output is written to `workdir/markdown/chunk-NNNN.md`.
+- [x] Pandoc errors are caught and reported with stderr output.
+- [x] Conversion time per chunk is logged.
+- [x] Unit tests verify correct Pandoc flags for each input format.
+
+Implemented in:
+- `docdown/stages/convert.py`
+- `docdown/cli.py`
+- `tests/test_convert.py`
+- `tests/test_cli.py`
 
 ## Implementation Notes
 
@@ -35,6 +41,51 @@ def convert_to_markdown(input_path, output_path):
         "--wrap=none",
         "-o", str(output_path),
     ], check=True, capture_output=True, text=True)
+```
+
+### Artifact Class Diagram
+
+```mermaid
+classDiagram
+    class PandocError {
+        <<exception>>
+    }
+
+    class ConvertStageModule {
+        <<module: docdown/stages/convert.py>>
+        +ensure_pandoc_available(logger) None
+        +convert_to_markdown(input_path, output_path, logger, chunk_number) Path
+        -_input_format_for_path(path) str
+    }
+
+    class CliModule {
+        <<module: docdown/cli.py>>
+        +main(...)
+    }
+
+    class WorkDir {
+        <<module: docdown/workdir.py>>
+        +markdown(chunk_number) Path
+    }
+
+    class PandocTool {
+        <<external: pandoc>>
+        +pandoc --version
+        +pandoc input -f tei|plain -t gfm --wrap=none -o output
+    }
+
+    class TestConvert {
+        <<tests/test_convert.py>>
+        +format flag tests
+        +availability test
+        +error handling tests
+    }
+
+    ConvertStageModule ..> PandocTool : invokes
+    ConvertStageModule ..> PandocError : raises
+    CliModule ..> ConvertStageModule : calls
+    CliModule ..> WorkDir : output path contract
+    TestConvert ..> ConvertStageModule : verifies behavior
 ```
 
 ### Pandoc availability

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,3 +199,90 @@ def test_cli_fails_when_all_conversions_fail(tmp_path, monkeypatch):
 
     assert result.exit_code != 0
     assert "Pandoc conversion failed for all extracted chunks" in result.output
+
+
+def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
+    captured: dict[str, object] = {}
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docdown.yaml").write_text("log_level: INFO\n", encoding="utf-8")
+
+    def _fake_load_config(config_path=None, cli_overrides=None):
+        captured["config_path"] = config_path
+        return SimpleNamespace(
+            input=dummy_pdf,
+            workdir=tmp_path / "out",
+            chunk_size=50,
+            extractor="pdfminer",
+            fallback_extractor="pdfminer",
+            grobid_url="http://localhost:8070",
+            log_level="INFO",
+        )
+
+    monkeypatch.setattr("docdown.cli.load_config", _fake_load_config)
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path)],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", lambda *args, **kwargs: tmp_path / "out" / "markdown" / "chunk-0001.md")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code == 0
+    assert captured["config_path"] == Path("docdown.yaml")
+
+
+def test_cli_uses_explicit_config_path_when_provided(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
+    explicit_config = tmp_path / "custom.yaml"
+    explicit_config.write_text("log_level: INFO\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def _fake_load_config(config_path=None, cli_overrides=None):
+        captured["config_path"] = config_path
+        return SimpleNamespace(
+            input=dummy_pdf,
+            workdir=tmp_path / "out",
+            chunk_size=50,
+            extractor="pdfminer",
+            fallback_extractor="pdfminer",
+            grobid_url="http://localhost:8070",
+            log_level="INFO",
+        )
+
+    monkeypatch.setattr("docdown.cli.load_config", _fake_load_config)
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path)],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", lambda *args, **kwargs: tmp_path / "out" / "markdown" / "chunk-0001.md")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--config", str(explicit_config)])
+
+    assert result.exit_code == 0
+    assert captured["config_path"] == explicit_config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,47 @@
 """Tests for the CLI entry point."""
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from click.testing import CliRunner
 from docdown import __version__
 from docdown.cli import main
+from docdown.stages.convert import PandocError
+from docdown.stages.split import PdfSplitError
 from docdown.stages.split import PdfValidationError
 
 
 def test_cli_shows_version(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
 
     monkeypatch.setattr(
         "docdown.cli.validate_pdf",
         lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
     )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [
+            SimpleNamespace(
+                chunk_number=1,
+                success=True,
+                output_path=extracted_path,
+            )
+        ],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -51,11 +77,28 @@ def test_cli_rejects_file_path_for_workdir(tmp_path):
 def test_cli_accepts_log_level_flag(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
 
     monkeypatch.setattr(
         "docdown.cli.validate_pdf",
         lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
     )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [
+            SimpleNamespace(
+                chunk_number=1,
+                success=True,
+                output_path=extracted_path,
+            )
+        ],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", lambda *args, **kwargs: tmp_path / "out" / "markdown" / "chunk-0001.md")
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--log-level", "debug"])
@@ -80,3 +123,79 @@ def test_cli_surfaces_pdf_validation_errors(tmp_path, monkeypatch):
 
     assert result.exit_code != 0
     assert "invalid pdf" in result.output
+
+
+def test_cli_surfaces_pdf_split_errors(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=5, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+
+    def _raise_split_error(*args, **kwargs):
+        raise PdfSplitError("split failed")
+
+    monkeypatch.setattr("docdown.cli.split_pdf", _raise_split_error)
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "split failed" in result.output
+
+
+def test_cli_fails_when_all_extractions_fail(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=False, output_path=None)],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "Extraction failed for all chunks" in result.output
+
+
+def test_cli_fails_when_all_conversions_fail(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path)],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+
+    def _raise_pandoc_error(*args, **kwargs):
+        raise PandocError("pandoc broke")
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _raise_pandoc_error)
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "Pandoc conversion failed for all extracted chunks" in result.output

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -74,7 +74,7 @@ def test_convert_to_markdown_uses_plain_for_txt_input(tmp_path, monkeypatch):
 
     convert_to_markdown(source, output)
     command = seen_commands[0]
-    assert "-f" in command and command[command.index("-f") + 1] == "plain"
+    assert "-f" in command and command[command.index("-f") + 1] == "markdown"
 
 
 def test_convert_to_markdown_rejects_unknown_extension(tmp_path):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -58,7 +58,7 @@ def test_convert_to_markdown_uses_tei_for_xml_input(tmp_path, monkeypatch):
     assert "--wrap=none" in command
 
 
-def test_convert_to_markdown_uses_plain_for_txt_input(tmp_path, monkeypatch):
+def test_convert_to_markdown_uses_markdown_for_txt_input(tmp_path, monkeypatch):
     source = tmp_path / "chunk-0002.txt"
     source.write_text("plain text", encoding="utf-8")
     output = tmp_path / "markdown" / "chunk-0002.md"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,1 +1,103 @@
-"""Tests for Markdown conversion."""
+"""Tests for Stage 3 Markdown conversion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from docdown.stages.convert import PandocError, convert_to_markdown, ensure_pandoc_available
+
+
+def _cp(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["pandoc"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_ensure_pandoc_available_succeeds(monkeypatch):
+    monkeypatch.setattr(
+        "docdown.stages.convert.subprocess.run",
+        lambda *args, **kwargs: _cp(0, stdout="pandoc 3.1.1\n"),
+    )
+
+    ensure_pandoc_available()
+
+
+def test_ensure_pandoc_available_missing_binary_raises_clear_error(monkeypatch):
+    def _raise_oserror(*args, **kwargs):
+        raise OSError("not found")
+
+    monkeypatch.setattr("docdown.stages.convert.subprocess.run", _raise_oserror)
+
+    with pytest.raises(PandocError, match="Pandoc is not available on PATH"):
+        ensure_pandoc_available()
+
+
+def test_convert_to_markdown_uses_tei_for_xml_input(tmp_path, monkeypatch):
+    source = tmp_path / "chunk-0001.xml"
+    source.write_text("<TEI>ok</TEI>", encoding="utf-8")
+    output = tmp_path / "markdown" / "chunk-0001.md"
+
+    seen_commands: list[list[str]] = []
+
+    def _fake_run(command, capture_output, text, check):
+        seen_commands.append(command)
+        Path(command[-1]).write_text("# converted", encoding="utf-8")
+        return _cp(0)
+
+    monkeypatch.setattr("docdown.stages.convert.subprocess.run", _fake_run)
+
+    result = convert_to_markdown(source, output)
+
+    assert result == output
+    assert output.exists()
+    command = seen_commands[0]
+    assert command[0] == "pandoc"
+    assert "-f" in command and command[command.index("-f") + 1] == "tei"
+    assert "-t" in command and command[command.index("-t") + 1] == "gfm"
+    assert "--wrap=none" in command
+
+
+def test_convert_to_markdown_uses_plain_for_txt_input(tmp_path, monkeypatch):
+    source = tmp_path / "chunk-0002.txt"
+    source.write_text("plain text", encoding="utf-8")
+    output = tmp_path / "markdown" / "chunk-0002.md"
+
+    seen_commands: list[list[str]] = []
+
+    def _fake_run(command, capture_output, text, check):
+        seen_commands.append(command)
+        Path(command[-1]).write_text("converted", encoding="utf-8")
+        return _cp(0)
+
+    monkeypatch.setattr("docdown.stages.convert.subprocess.run", _fake_run)
+
+    convert_to_markdown(source, output)
+    command = seen_commands[0]
+    assert "-f" in command and command[command.index("-f") + 1] == "plain"
+
+
+def test_convert_to_markdown_rejects_unknown_extension(tmp_path):
+    source = tmp_path / "chunk-0003.json"
+    source.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(PandocError, match="Unsupported conversion input extension"):
+        convert_to_markdown(source, tmp_path / "out.md")
+
+
+def test_convert_to_markdown_rejects_missing_input(tmp_path):
+    with pytest.raises(PandocError, match="Conversion input not found"):
+        convert_to_markdown(tmp_path / "missing.xml", tmp_path / "out.md")
+
+
+def test_convert_to_markdown_surfaces_pandoc_stderr(tmp_path, monkeypatch):
+    source = tmp_path / "chunk-0004.xml"
+    source.write_text("<TEI>", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "docdown.stages.convert.subprocess.run",
+        lambda *args, **kwargs: _cp(2, stderr="parse failure"),
+    )
+
+    with pytest.raises(PandocError, match="parse failure"):
+        convert_to_markdown(source, tmp_path / "out.md")


### PR DESCRIPTION
## Summary
- wire CLI flow through split, extraction orchestration, and conversion
- implement Pandoc conversion stage with availability checks and robust error handling
- add/expand CLI and conversion tests
- update task planning docs and add Docker/WSL/GROBID setup troubleshooting note
- set default extractor configuration to pdfminer for current workflow

## Validation
- pytest -q
- external smoke runs completed with extracted and markdown outputs (pdfminer path)
