### PR TITLE
Task 4.2: post-conversion markdown cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+# Copilot Instructions
+
+## PR Review Workflow
+
+- During PR review, do not create commits or push changes unless the user explicitly asks for commit and/or push.
+- Default review behavior: analyze feedback, propose or apply edits locally, run validation, and stop before commit/push.
+- If commit/push is needed, ask for explicit approval first.

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 
 from docdown.config import ConfigError, load_config
+from docdown.stages.cleanup import CleanupError, cleanup_markdown_file
 from docdown.stages.convert import PandocError, convert_to_markdown, ensure_pandoc_available
 from docdown.stages.extract import orchestrate_extraction
 from docdown.stages.split import PdfSplitError, PdfValidationError, split_pdf, validate_pdf
@@ -159,8 +160,13 @@ def main(
                 logger=logger,
                 chunk_number=result.chunk_number,
             )
-        except PandocError as exc:
-            logger.error("Pandoc conversion failed for chunk-%04d: %s", result.chunk_number, exc)
+            cleanup_markdown_file(
+                markdown_path,
+                logger=logger,
+                chunk_number=result.chunk_number,
+            )
+        except (PandocError, CleanupError) as exc:
+            logger.error("Markdown conversion/cleanup failed for chunk-%04d: %s", result.chunk_number, exc)
             continue
         converted_chunks += 1
 

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -171,7 +171,7 @@ def main(
         converted_chunks += 1
 
     if converted_chunks == 0:
-        raise click.ClickException("Pandoc conversion failed for all extracted chunks.")
+        raise click.ClickException("Markdown conversion/cleanup failed for all extracted chunks.")
 
     logger.info("Conversion summary: %s converted, %s extraction successes skipped/failed", converted_chunks, len(successful_extractions) - converted_chunks)
 

--- a/docdown/stages/cleanup.py
+++ b/docdown/stages/cleanup.py
@@ -56,7 +56,7 @@ def cleanup_markdown_text(
 
     cleaned = strip_trailing_whitespace(normalized)
     cleaned = remove_repeated_header_footer_lines(cleaned, logger=active_logger, chunk_number=chunk_number)
-    cleaned = normalise_headings(cleaned)
+    cleaned = normalize_headings(cleaned)
     cleaned = collapse_blank_lines(cleaned)
 
     if trailing_newline and cleaned and not cleaned.endswith("\n"):
@@ -71,7 +71,7 @@ def collapse_blank_lines(text: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", text)
 
 
-def normalise_headings(text: str) -> str:
+def normalize_headings(text: str) -> str:
     """Demote headings by one level when H1 headings are present."""
 
     if re.search(r"^# ", text, flags=re.MULTILINE):

--- a/docdown/stages/cleanup.py
+++ b/docdown/stages/cleanup.py
@@ -103,11 +103,13 @@ def remove_repeated_header_footer_lines(
         return text
 
     occurrences: dict[str, int] = {}
+    considered_blocks = 0
     for block in blocks:
         lines = [line.rstrip(" \t") for line in block.split("\n")]
         non_empty = [line for line in lines if line.strip()]
         if not non_empty:
             continue
+        considered_blocks += 1
 
         edge_candidates = non_empty[:edge_line_count] + non_empty[-edge_line_count:]
         for candidate in set(edge_candidates):
@@ -116,7 +118,10 @@ def remove_repeated_header_footer_lines(
     if not occurrences:
         return text
 
-    threshold = len(blocks) / 2
+    if considered_blocks == 0:
+        return text
+
+    threshold = considered_blocks / 2
     repeated = {line for line, count in occurrences.items() if count > threshold}
     if not repeated:
         return text

--- a/docdown/stages/cleanup.py
+++ b/docdown/stages/cleanup.py
@@ -1,0 +1,140 @@
+"""Stage 4.2 — Post-conversion Markdown cleanup."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import re
+
+from docdown.utils.logging import get_logger
+
+
+LogLike = logging.Logger | logging.LoggerAdapter
+
+
+class CleanupError(ValueError):
+    """Raised when markdown cleanup fails."""
+
+
+def cleanup_markdown_file(
+    markdown_path: Path,
+    *,
+    logger: LogLike | None = None,
+    chunk_number: int | None = None,
+) -> Path:
+    """Apply cleanup rules in-place to a markdown chunk file."""
+
+    path = Path(markdown_path)
+    active_logger = logger or get_logger()
+
+    if not path.exists() or not path.is_file():
+        raise CleanupError(f"Markdown cleanup input not found: {path}")
+
+    original = path.read_text(encoding="utf-8")
+    cleaned = cleanup_markdown_text(original, logger=active_logger, chunk_number=chunk_number)
+
+    if cleaned != original:
+        path.write_text(cleaned, encoding="utf-8")
+        active_logger.debug("Markdown cleanup updated %s", path.name)
+    else:
+        active_logger.debug("Markdown cleanup made no changes to %s", path.name)
+
+    return path
+
+
+def cleanup_markdown_text(
+    text: str,
+    *,
+    logger: LogLike | None = None,
+    chunk_number: int | None = None,
+) -> str:
+    """Apply all markdown cleanup rules and return cleaned text."""
+
+    active_logger = logger or get_logger()
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    trailing_newline = normalized.endswith("\n")
+
+    cleaned = strip_trailing_whitespace(normalized)
+    cleaned = remove_repeated_header_footer_lines(cleaned, logger=active_logger, chunk_number=chunk_number)
+    cleaned = normalise_headings(cleaned)
+    cleaned = collapse_blank_lines(cleaned)
+
+    if trailing_newline and cleaned and not cleaned.endswith("\n"):
+        cleaned = f"{cleaned}\n"
+
+    return cleaned
+
+
+def collapse_blank_lines(text: str) -> str:
+    """Collapse runs of 3+ blank lines to exactly two newlines."""
+
+    return re.sub(r"\n{3,}", "\n\n", text)
+
+
+def normalise_headings(text: str) -> str:
+    """Demote headings by one level when H1 headings are present."""
+
+    if re.search(r"^# ", text, flags=re.MULTILINE):
+        return re.sub(r"^(#{1,5}) ", lambda match: f"#{match.group(1)} ", text, flags=re.MULTILINE)
+    return text
+
+
+def strip_trailing_whitespace(text: str) -> str:
+    """Trim trailing spaces/tabs from each line."""
+
+    lines = text.split("\n")
+    return "\n".join(line.rstrip(" \t") for line in lines)
+
+
+def remove_repeated_header_footer_lines(
+    text: str,
+    *,
+    logger: LogLike | None = None,
+    chunk_number: int | None = None,
+    edge_line_count: int = 2,
+) -> str:
+    """Remove repeated edge lines seen in a majority of page-equivalent blocks."""
+
+    if edge_line_count <= 0:
+        return text
+
+    blocks = text.split("\f")
+    if len(blocks) < 2:
+        return text
+
+    occurrences: dict[str, int] = {}
+    for block in blocks:
+        lines = [line.rstrip(" \t") for line in block.split("\n")]
+        non_empty = [line for line in lines if line.strip()]
+        if not non_empty:
+            continue
+
+        edge_candidates = non_empty[:edge_line_count] + non_empty[-edge_line_count:]
+        for candidate in set(edge_candidates):
+            occurrences[candidate] = occurrences.get(candidate, 0) + 1
+
+    if not occurrences:
+        return text
+
+    threshold = len(blocks) / 2
+    repeated = {line for line, count in occurrences.items() if count > threshold}
+    if not repeated:
+        return text
+
+    active_logger = logger or get_logger()
+    if chunk_number is not None:
+        active_logger.debug(
+            "Removed repeated header/footer lines from chunk-%04d: %s",
+            chunk_number,
+            sorted(repeated),
+        )
+    else:
+        active_logger.debug("Removed repeated header/footer lines: %s", sorted(repeated))
+
+    cleaned_blocks: list[str] = []
+    for block in blocks:
+        lines = block.split("\n")
+        kept_lines = [line for line in lines if line.rstrip(" \t") not in repeated]
+        cleaned_blocks.append("\n".join(kept_lines))
+
+    return "\f".join(cleaned_blocks)

--- a/docdown/stages/cleanup.py
+++ b/docdown/stages/cleanup.py
@@ -139,7 +139,19 @@ def remove_repeated_header_footer_lines(
     cleaned_blocks: list[str] = []
     for block in blocks:
         lines = block.split("\n")
-        kept_lines = [line for line in lines if line.rstrip(" \t") not in repeated]
+        non_empty_indices = [index for index, line in enumerate(lines) if line.strip()]
+        if not non_empty_indices:
+            cleaned_blocks.append(block)
+            continue
+
+        edge_indices = set(non_empty_indices[:edge_line_count])
+        edge_indices.update(non_empty_indices[-edge_line_count:])
+
+        kept_lines = [
+            line
+            for index, line in enumerate(lines)
+            if not (index in edge_indices and line.rstrip(" \t") in repeated)
+        ]
         cleaned_blocks.append("\n".join(kept_lines))
 
     return "\f".join(cleaned_blocks)

--- a/docs/plan/task-4.2-markdown-cleanup.md
+++ b/docs/plan/task-4.2-markdown-cleanup.md
@@ -10,13 +10,19 @@ Apply automated cleanup rules to each chunk's Markdown output to normalise forma
 
 ## Acceptance Criteria
 
-- [ ] Excessive blank lines are collapsed (>2 consecutive → 2).
-- [ ] Heading levels are normalised: no chunk starts below `##` (reserve `#` for document title).
-- [ ] Repeated page header/footer lines are detected and removed.
-- [ ] Trailing whitespace on each line is stripped.
-- [ ] Output overwrites the chunk Markdown file in place.
-- [ ] Cleanup is idempotent (running twice produces the same result).
-- [ ] Unit tests cover each cleanup rule independently.
+- [x] Excessive blank lines are collapsed (>2 consecutive → 2).
+- [x] Heading levels are normalised: no chunk starts below `##` (reserve `#` for document title).
+- [x] Repeated page header/footer lines are detected and removed.
+- [x] Trailing whitespace on each line is stripped.
+- [x] Output overwrites the chunk Markdown file in place.
+- [x] Cleanup is idempotent (running twice produces the same result).
+- [x] Unit tests cover each cleanup rule independently.
+
+Implemented in:
+- `docdown/stages/cleanup.py`
+- `docdown/cli.py`
+- `tests/test_cleanup.py`
+- `tests/test_cli.py`
 
 ## Implementation Notes
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -63,6 +63,28 @@ def test_remove_repeated_header_footer_lines_removes_majority_edges():
     assert "Body A" in cleaned and "Body B" in cleaned and "Body C" in cleaned
 
 
+def test_remove_repeated_header_footer_lines_ignores_empty_blocks_for_threshold():
+    text = (
+        "\f"
+        "Doc Header\n"
+        "Page 1 intro\n"
+        "Body A\n"
+        "Doc Footer\n"
+        "\f\f"
+        "Doc Header\n"
+        "Page 2 intro\n"
+        "Body B\n"
+        "Doc Footer\n"
+        "\f"
+    )
+
+    cleaned = remove_repeated_header_footer_lines(text)
+
+    assert "Doc Header" not in cleaned
+    assert "Doc Footer" not in cleaned
+    assert "Body A" in cleaned and "Body B" in cleaned
+
+
 def test_strip_trailing_whitespace_removes_line_suffix_spaces_tabs():
     text = "alpha  \n beta\t\ncharlie\n"
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from docdown.stages.cleanup import (
     cleanup_markdown_file,
     cleanup_markdown_text,

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -83,6 +83,31 @@ def test_remove_repeated_header_footer_lines_ignores_empty_blocks_for_threshold(
     assert "Body A" in cleaned and "Body B" in cleaned
 
 
+def test_remove_repeated_header_footer_lines_keeps_matching_body_lines():
+    text = (
+        "Doc Header\n"
+        "Top A\n"
+        "Doc Header\n"
+        "Bottom A\n"
+        "Doc Footer\n"
+        "\f"
+        "Doc Header\n"
+        "Top B\n"
+        "Doc Header\n"
+        "Bottom B\n"
+        "Doc Footer\n"
+    )
+
+    cleaned = remove_repeated_header_footer_lines(text)
+
+    # Edge header/footer lines are removed per block.
+    assert cleaned.split("\f")[0].split("\n")[0] != "Doc Header"
+    assert cleaned.split("\f")[1].split("\n")[-1] != "Doc Footer"
+    # Interior lines with the same text remain untouched.
+    assert "Top A\nDoc Header\nBottom A" in cleaned
+    assert "Top B\nDoc Header\nBottom B" in cleaned
+
+
 def test_strip_trailing_whitespace_removes_line_suffix_spaces_tabs():
     text = "alpha  \n beta\t\ncharlie\n"
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,89 @@
+"""Tests for Stage 4.2 markdown cleanup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from docdown.stages.cleanup import (
+    cleanup_markdown_file,
+    cleanup_markdown_text,
+    collapse_blank_lines,
+    normalise_headings,
+    remove_repeated_header_footer_lines,
+    strip_trailing_whitespace,
+)
+
+
+def test_collapse_blank_lines_reduces_runs_over_two():
+    text = "line1\n\n\n\nline2\n"
+
+    cleaned = collapse_blank_lines(text)
+
+    assert cleaned == "line1\n\nline2\n"
+
+
+def test_normalise_headings_demotes_when_h1_present():
+    text = "# Title\n## Section\n### Subsection\n"
+
+    cleaned = normalise_headings(text)
+
+    assert cleaned == "## Title\n### Section\n#### Subsection\n"
+
+
+def test_normalise_headings_no_change_without_h1():
+    text = "## Section\n### Subsection\n"
+
+    cleaned = normalise_headings(text)
+
+    assert cleaned == text
+
+
+def test_remove_repeated_header_footer_lines_removes_majority_edges():
+    text = (
+        "Doc Header\n"
+        "Page 1 intro\n"
+        "Body A\n"
+        "Doc Footer\n"
+        "\f"
+        "Doc Header\n"
+        "Page 2 intro\n"
+        "Body B\n"
+        "Doc Footer\n"
+        "\f"
+        "Doc Header\n"
+        "Page 3 intro\n"
+        "Body C\n"
+        "Doc Footer\n"
+    )
+
+    cleaned = remove_repeated_header_footer_lines(text)
+
+    assert "Doc Header" not in cleaned
+    assert "Doc Footer" not in cleaned
+    assert "Body A" in cleaned and "Body B" in cleaned and "Body C" in cleaned
+
+
+def test_strip_trailing_whitespace_removes_line_suffix_spaces_tabs():
+    text = "alpha  \n beta\t\ncharlie\n"
+
+    cleaned = strip_trailing_whitespace(text)
+
+    assert cleaned == "alpha\n beta\ncharlie\n"
+
+
+def test_cleanup_markdown_file_overwrites_in_place(tmp_path):
+    path = tmp_path / "chunk-0001.md"
+    path.write_text("# Heading\n\n\nline  \n", encoding="utf-8")
+
+    cleanup_markdown_file(path)
+
+    assert path.read_text(encoding="utf-8") == "## Heading\n\nline\n"
+
+
+def test_cleanup_markdown_text_is_idempotent():
+    text = "# Heading\n\n\nDoc Header\nBody\nDoc Footer\n\f\nDoc Header\nBody 2\nDoc Footer\n"
+
+    once = cleanup_markdown_text(text)
+    twice = cleanup_markdown_text(once)
+
+    assert twice == once

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -8,7 +8,7 @@ from docdown.stages.cleanup import (
     cleanup_markdown_file,
     cleanup_markdown_text,
     collapse_blank_lines,
-    normalise_headings,
+    normalize_headings,
     remove_repeated_header_footer_lines,
     strip_trailing_whitespace,
 )
@@ -22,18 +22,18 @@ def test_collapse_blank_lines_reduces_runs_over_two():
     assert cleaned == "line1\n\nline2\n"
 
 
-def test_normalise_headings_demotes_when_h1_present():
+def test_normalize_headings_demotes_when_h1_present():
     text = "# Title\n## Section\n### Subsection\n"
 
-    cleaned = normalise_headings(text)
+    cleaned = normalize_headings(text)
 
     assert cleaned == "## Title\n### Section\n#### Subsection\n"
 
 
-def test_normalise_headings_no_change_without_h1():
+def test_normalize_headings_no_change_without_h1():
     text = "## Section\n### Subsection\n"
 
-    cleaned = normalise_headings(text)
+    cleaned = normalize_headings(text)
 
     assert cleaned == text
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,7 +176,7 @@ def test_cli_fails_when_all_extractions_fail(tmp_path, monkeypatch):
     assert "Extraction failed for all chunks" in result.output
 
 
-def test_cli_fails_when_all_conversions_fail(tmp_path, monkeypatch):
+def test_cli_fails_when_all_conversion_or_cleanup_steps_fail(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
     extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
@@ -204,7 +204,7 @@ def test_cli_fails_when_all_conversions_fail(tmp_path, monkeypatch):
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code != 0
-    assert "Pandoc conversion failed for all extracted chunks" in result.output
+    assert "Markdown conversion/cleanup failed for all extracted chunks" in result.output
 
 
 def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,7 +98,13 @@ def test_cli_accepts_log_level_flag(tmp_path, monkeypatch):
         ],
     )
     monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
-    monkeypatch.setattr("docdown.cli.convert_to_markdown", lambda *args, **kwargs: tmp_path / "out" / "markdown" / "chunk-0001.md")
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--log-level", "debug"])
@@ -236,7 +242,13 @@ def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):
         lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path)],
     )
     monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
-    monkeypatch.setattr("docdown.cli.convert_to_markdown", lambda *args, **kwargs: tmp_path / "out" / "markdown" / "chunk-0001.md")
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -279,7 +291,13 @@ def test_cli_uses_explicit_config_path_when_provided(tmp_path, monkeypatch):
         lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path)],
     )
     monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
-    monkeypatch.setattr("docdown.cli.convert_to_markdown", lambda *args, **kwargs: tmp_path / "out" / "markdown" / "chunk-0001.md")
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--config", str(explicit_config)])


### PR DESCRIPTION
## Summary
- add Stage 4.2 markdown cleanup module for per-chunk post-conversion normalization
- wire cleanup into CLI immediately after Pandoc conversion for each successful chunk
- keep cleanup in-place and chunk-aware with DEBUG logging for repeated header/footer removals
- update Task 4.2 plan doc acceptance checklist and implemented file references

## Cleanup Rules Implemented
- collapse excessive blank lines (3+ newlines -> 2)
- demote headings by one level when any H1 is present (preserves relative structure)
- remove repeated header/footer lines that appear in more than 50% of page-equivalent blocks (\f-separated)
- strip trailing whitespace per line
- ensure idempotent cleanup behavior

## Tests
- add dedicated unit coverage in 	ests/test_cleanup.py for each cleanup rule and idempotency
- update CLI tests to account for cleanup running after conversion
- full suite: 109 passed, 1 skipped

## Smoke Validation
- external run completed successfully:
  - input: uns/external-smoke-102/input/source.pdf
  - output: uns/external-smoke-104
  - artifacts: chunks=1, xtracted=1, markdown=1
  - quick checks on produced markdown: no H1 headings, no triple blank lines, no trailing whitespace