### PR TITLE
Task 6.2: Generate TOC into final.md

### DIFF
--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -194,7 +194,7 @@ def main(
         generate_toc(
             work_dir.merged_markdown(),
             work_dir.final_markdown(),
-            toc_depth=getattr(cfg, "toc_depth", 3),
+            toc_depth=cfg.toc_depth,
             logger=logger,
         )
     except TocError as exc:

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -10,6 +10,7 @@ from docdown.stages.convert import PandocError, convert_to_markdown, ensure_pand
 from docdown.stages.extract import orchestrate_extraction
 from docdown.stages.merge import MergeError, merge_chunks
 from docdown.stages.split import PdfSplitError, PdfValidationError, split_pdf, validate_pdf
+from docdown.stages.toc import TocError, generate_toc
 from docdown.utils.logging import configure_logging
 from docdown.workdir import WorkDir, WorkDirError
 
@@ -37,6 +38,7 @@ from docdown.workdir import WorkDir, WorkDirError
 @click.option("--table-extraction/--no-table-extraction", default=None, help="Enable table extraction")
 @click.option("--llm-cleanup/--no-llm-cleanup", default=None, help="Enable LLM cleanup pipeline")
 @click.option("--llm-model", type=str, default=None, help="LLM model identifier")
+@click.option("--toc-depth", type=int, default=None, help="TOC maximum heading depth (1-6)")
 @click.option(
     "--log-level",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "WARN"], case_sensitive=False),
@@ -57,6 +59,7 @@ def main(
     table_extraction,
     llm_cleanup,
     llm_model,
+    toc_depth,
     log_level,
     min_output_ratio,
     max_empty_chunks,
@@ -74,6 +77,7 @@ def main(
         "table_extraction": table_extraction,
         "llm_cleanup": llm_cleanup,
         "llm_model": llm_model,
+        "toc_depth": toc_depth,
         "log_level": log_level,
         "validation": {
             "min_output_ratio": min_output_ratio,
@@ -184,6 +188,16 @@ def main(
             logger=logger,
         )
     except MergeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        generate_toc(
+            work_dir.merged_markdown(),
+            work_dir.final_markdown(),
+            toc_depth=getattr(cfg, "toc_depth", 3),
+            logger=logger,
+        )
+    except TocError as exc:
         raise click.ClickException(str(exc)) from exc
 
 

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -38,7 +38,7 @@ from docdown.workdir import WorkDir, WorkDirError
 @click.option("--table-extraction/--no-table-extraction", default=None, help="Enable table extraction")
 @click.option("--llm-cleanup/--no-llm-cleanup", default=None, help="Enable LLM cleanup pipeline")
 @click.option("--llm-model", type=str, default=None, help="LLM model identifier")
-@click.option("--toc-depth", type=int, default=None, help="TOC maximum heading depth (1-6)")
+@click.option("--toc-depth", type=click.IntRange(1, 6), default=None, help="TOC maximum heading depth (1-6)")
 @click.option(
     "--log-level",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "WARN"], case_sensitive=False),

--- a/docdown/config.py
+++ b/docdown/config.py
@@ -40,6 +40,7 @@ class Config:
     table_extraction: bool = True
     llm_cleanup: bool = False
     llm_model: str | None = None
+    toc_depth: int = 3
     log_level: str = "INFO"
     validation: ValidationConfig = field(default_factory=ValidationConfig)
 
@@ -75,6 +76,7 @@ def _default_data() -> dict[str, Any]:
         "table_extraction": defaults.table_extraction,
         "llm_cleanup": defaults.llm_cleanup,
         "llm_model": defaults.llm_model,
+        "toc_depth": defaults.toc_depth,
         "log_level": defaults.log_level,
         "validation": {
             "min_output_ratio": defaults.validation.min_output_ratio,
@@ -162,6 +164,7 @@ def _build_and_validate(data: dict[str, Any]) -> Config:
             table_extraction=_require_bool(data["table_extraction"], "table_extraction"),
             llm_cleanup=_require_bool(data["llm_cleanup"], "llm_cleanup"),
             llm_model=str(data["llm_model"]) if data["llm_model"] is not None else None,
+            toc_depth=_require_int(data["toc_depth"], "toc_depth"),
             log_level=str(data["log_level"]).upper(),
             validation=validation_cfg,
         )
@@ -197,6 +200,8 @@ def _validate_semantics(cfg: Config) -> None:
         raise ConfigError(f"extractor must be one of: {sorted(_VALID_EXTRACTORS)}")
     if cfg.fallback_extractor not in _VALID_EXTRACTORS:
         raise ConfigError(f"fallback_extractor must be one of: {sorted(_VALID_EXTRACTORS)}")
+    if cfg.toc_depth < 1 or cfg.toc_depth > 6:
+        raise ConfigError("toc_depth must be between 1 and 6.")
     if cfg.log_level not in _VALID_LOG_LEVELS:
         raise ConfigError(f"log_level must be one of: {sorted(_VALID_LOG_LEVELS)}")
     if not math.isfinite(cfg.validation.min_output_ratio):

--- a/docdown/stages/toc.py
+++ b/docdown/stages/toc.py
@@ -67,12 +67,26 @@ def generate_toc(
     try:
         result = subprocess.run(command, capture_output=True, text=True, check=False)
     except OSError as exc:
-        _copy_without_toc(source, target, active_logger, reason=f"pandoc unavailable: {exc}")
+        _copy_without_toc(
+            source,
+            target,
+            active_logger,
+            reason=f"pandoc unavailable: {exc}",
+            entry_count=entry_count,
+            toc_depth=toc_depth,
+        )
         return target
 
     if result.returncode != 0:
         diagnostics = _combined_output(result)
-        _copy_without_toc(source, target, active_logger, reason=f"pandoc failed: {diagnostics}")
+        _copy_without_toc(
+            source,
+            target,
+            active_logger,
+            reason=f"pandoc failed: {diagnostics}",
+            entry_count=entry_count,
+            toc_depth=toc_depth,
+        )
         return target
 
     active_logger.info(
@@ -84,7 +98,15 @@ def generate_toc(
     return target
 
 
-def _copy_without_toc(source: Path, target: Path, logger: LogLike, *, reason: str) -> None:
+def _copy_without_toc(
+    source: Path,
+    target: Path,
+    logger: LogLike,
+    *,
+    reason: str,
+    entry_count: int,
+    toc_depth: int,
+) -> None:
     """Fallback to a direct merged->final copy when pandoc TOC generation is unavailable."""
 
     try:
@@ -93,7 +115,7 @@ def _copy_without_toc(source: Path, target: Path, logger: LogLike, *, reason: st
         raise TocError(f"TOC fallback copy failed from {source} to {target}: {exc}") from exc
 
     logger.warning("TOC generation degraded; copied merged markdown without TOC: %s", reason)
-    logger.info("TOC generation complete: entries=%s depth=%s path=%s", 0, "-", target)
+    logger.info("TOC generation complete: entries=%s depth=%s path=%s", entry_count, toc_depth, target)
 
 
 def _count_headings_for_toc(markdown_lines: Iterable[str] | str, toc_depth: int) -> int:

--- a/docdown/stages/toc.py
+++ b/docdown/stages/toc.py
@@ -125,13 +125,16 @@ def _count_headings_for_toc(markdown_lines: Iterable[str] | str, toc_depth: int)
     in_fenced_block = False
     lines = markdown_lines.splitlines() if isinstance(markdown_lines, str) else markdown_lines
     for line in lines:
-        if line.startswith("```") or line.startswith("~~~"):
+        normalized = line.lstrip(" ")
+        leading_spaces = len(line) - len(normalized)
+
+        if leading_spaces <= 3 and (normalized.startswith("```") or normalized.startswith("~~~")):
             in_fenced_block = not in_fenced_block
             continue
         if in_fenced_block:
             continue
 
-        match = re.match(r"^(#{1,6})[ \t]+.+$", line)
+        match = re.match(r"^ {0,3}(#{1,6})[ \t]+.+$", line)
         if match is None:
             continue
 

--- a/docdown/stages/toc.py
+++ b/docdown/stages/toc.py
@@ -1,0 +1,124 @@
+"""Stage 6.2 - TOC generation for merged markdown output."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+from docdown.utils.logging import get_logger, log_tool_command
+
+
+LogLike = logging.Logger | logging.LoggerAdapter
+
+
+class TocError(ValueError):
+    """Raised when TOC generation inputs are invalid or fallback copy fails."""
+
+
+def generate_toc(
+    merged_path: Path,
+    final_path: Path,
+    *,
+    toc_depth: int = 3,
+    logger: LogLike | None = None,
+) -> Path:
+    """Generate a TOC-enhanced markdown output via Pandoc, with copy fallback on tool failure."""
+
+    source = Path(merged_path)
+    target = Path(final_path)
+    active_logger = logger or get_logger()
+
+    if toc_depth < 1 or toc_depth > 6:
+        raise TocError(f"toc_depth must be between 1 and 6, got {toc_depth}")
+
+    if not source.exists() or not source.is_file():
+        raise TocError(f"Merged markdown input not found: {source}")
+
+    try:
+        merged_text = source.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TocError(f"Failed reading merged markdown {source}: {exc}") from exc
+
+    entry_count = _count_headings_for_toc(merged_text, toc_depth)
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise TocError(f"Failed preparing final markdown output path {target}: {exc}") from exc
+
+    command = [
+        "pandoc",
+        str(source),
+        "-f",
+        "gfm",
+        "-t",
+        "gfm",
+        "--wrap=none",
+        "--toc",
+        f"--toc-depth={toc_depth}",
+        "-o",
+        str(target),
+    ]
+    log_tool_command(command)
+
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        _copy_without_toc(source, target, active_logger, reason=f"pandoc unavailable: {exc}")
+        return target
+
+    if result.returncode != 0:
+        diagnostics = _combined_output(result)
+        _copy_without_toc(source, target, active_logger, reason=f"pandoc failed: {diagnostics}")
+        return target
+
+    active_logger.info(
+        "TOC generation complete: entries=%s depth=%s path=%s",
+        entry_count,
+        toc_depth,
+        target,
+    )
+    return target
+
+
+def _copy_without_toc(source: Path, target: Path, logger: LogLike, *, reason: str) -> None:
+    """Fallback to a direct merged->final copy when pandoc TOC generation is unavailable."""
+
+    try:
+        shutil.copyfile(source, target)
+    except OSError as exc:
+        raise TocError(f"TOC fallback copy failed from {source} to {target}: {exc}") from exc
+
+    logger.warning("TOC generation degraded; copied merged markdown without TOC: %s", reason)
+    logger.info("TOC generation complete: entries=%s depth=%s path=%s", 0, "-", target)
+
+
+def _count_headings_for_toc(markdown_text: str, toc_depth: int) -> int:
+    """Count ATX headings eligible for TOC inclusion up to the requested depth."""
+
+    count = 0
+    in_fenced_block = False
+    for line in markdown_text.splitlines():
+        if line.startswith("```") or line.startswith("~~~"):
+            in_fenced_block = not in_fenced_block
+            continue
+        if in_fenced_block:
+            continue
+
+        match = re.match(r"^(#{1,6})[ \t]+.+$", line)
+        if match is None:
+            continue
+
+        level = len(match.group(1))
+        if level <= toc_depth:
+            count += 1
+
+    return count
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    combined = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+    return combined if combined else "<no diagnostics>"

--- a/docdown/stages/toc.py
+++ b/docdown/stages/toc.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
+from typing import Iterable
 
 from docdown.utils.logging import get_logger, log_tool_command
 
@@ -38,11 +39,10 @@ def generate_toc(
         raise TocError(f"Merged markdown input not found: {source}")
 
     try:
-        merged_text = source.read_text(encoding="utf-8")
+        with source.open("r", encoding="utf-8", newline="") as handle:
+            entry_count = _count_headings_for_toc(handle, toc_depth)
     except OSError as exc:
         raise TocError(f"Failed reading merged markdown {source}: {exc}") from exc
-
-    entry_count = _count_headings_for_toc(merged_text, toc_depth)
 
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -96,12 +96,13 @@ def _copy_without_toc(source: Path, target: Path, logger: LogLike, *, reason: st
     logger.info("TOC generation complete: entries=%s depth=%s path=%s", 0, "-", target)
 
 
-def _count_headings_for_toc(markdown_text: str, toc_depth: int) -> int:
+def _count_headings_for_toc(markdown_lines: Iterable[str] | str, toc_depth: int) -> int:
     """Count ATX headings eligible for TOC inclusion up to the requested depth."""
 
     count = 0
     in_fenced_block = False
-    for line in markdown_text.splitlines():
+    lines = markdown_lines.splitlines() if isinstance(markdown_lines, str) else markdown_lines
+    for line in lines:
         if line.startswith("```") or line.startswith("~~~"):
             in_fenced_block = not in_fenced_block
             continue

--- a/docs/plan/task-6.2-toc-generation.md
+++ b/docs/plan/task-6.2-toc-generation.md
@@ -10,43 +10,95 @@ Generate a Table of Contents from the merged Markdown headings using Pandoc.
 
 ## Acceptance Criteria
 
-- [ ] Pandoc generates a TOC from `merged.md` headings up to depth 3 (`#`, `##`, `###`).
-- [ ] TOC is inserted at the top of the document.
-- [ ] Output is written to `workdir/final.md`.
-- [ ] If Pandoc fails, `merged.md` is copied to `final.md` without a TOC (degraded but usable).
-- [ ] TOC depth is configurable (default: 3).
-- [ ] Log the number of TOC entries generated.
-- [ ] Unit test verifies TOC is present in output for a document with headings.
+- [x] Pandoc generates a TOC from `merged.md` headings up to depth 3 (`#`, `##`, `###`).
+- [x] TOC is inserted at the top of the document.
+- [x] Output is written to `workdir/final.md`.
+- [x] If Pandoc fails, `merged.md` is copied to `final.md` without a TOC (degraded but usable).
+- [x] TOC depth is configurable (default: 3).
+- [x] Log the number of TOC entries generated.
+- [x] Unit test verifies TOC is present in output for a document with headings.
+
+Implemented in:
+- `docdown/stages/toc.py`
+- `docdown/cli.py`
+- `docdown/config.py`
+- `tests/test_toc.py`
+- `tests/test_cli.py`
+- `tests/test_config.py`
 
 ## Implementation Notes
 
-### Command
+### Implementation
 
 ```bash
 pandoc merged.md -f gfm -t gfm --toc --toc-depth=3 -o final.md
 ```
 
-### Alternative: Python-based TOC
+TOC generation now runs in a dedicated stage (`docdown/stages/toc.py`) with the following behavior:
 
-If Pandoc's `--toc` for GFM output is insufficient (it may not produce GFM-compatible link anchors), implement a simple Python TOC generator:
+- Primary path: invoke Pandoc with `--toc` and configurable `--toc-depth`.
+- Fallback path: if Pandoc execution fails (missing binary or non-zero exit), copy `merged.md` to `final.md` and log a degraded-mode warning.
+- Metrics: log TOC entry count based on headings found in `merged.md` up to configured depth.
 
 ```python
-import re
+from docdown.stages.toc import generate_toc
 
-def generate_toc(text, max_depth=3):
-    toc_lines = []
-    for match in re.finditer(r"^(#{1,6}) (.+)$", text, re.MULTILINE):
-        level = len(match.group(1))
-        if level > max_depth:
-            continue
-        title = match.group(2).strip()
-        anchor = re.sub(r"[^\w\s-]", "", title.lower()).replace(" ", "-")
-        indent = "  " * (level - 1)
-        toc_lines.append(f"{indent}- [{title}](#{anchor})")
-    return "\n".join(toc_lines)
+generate_toc(
+    work_dir.merged_markdown(),
+    work_dir.final_markdown(),
+    toc_depth=cfg.toc_depth,
+    logger=logger,
+)
 ```
 
-Decide at implementation time which approach produces better results.
+### Artifact Class Diagram
+
+```mermaid
+classDiagram
+    class TocError {
+        <<exception>>
+    }
+
+    class TocStageModule {
+        <<module: docdown/stages/toc.py>>
+        +generate_toc(merged_path, final_path, toc_depth, logger) Path
+    }
+
+    class CliModule {
+        <<module: docdown/cli.py>>
+        +main(...)
+    }
+
+    class Config {
+        <<module: docdown/config.py>>
+        +toc_depth int
+    }
+
+    class WorkDir {
+        <<module: docdown/workdir.py>>
+        +merged_markdown() Path
+        +final_markdown() Path
+    }
+
+    class TestToc {
+        <<tests/test_toc.py>>
+        +pandoc success test
+        +fallback copy test
+        +depth validation test
+    }
+
+    class TestCli {
+        <<tests/test_cli.py>>
+        +TOC error propagation test
+    }
+
+    CliModule ..> Config : reads toc_depth
+    CliModule ..> WorkDir : resolves merged/final paths
+    CliModule ..> TocStageModule : calls after merge
+    TocStageModule ..> TocError : raises on invalid/fallback-copy failures
+    TestToc ..> TocStageModule : verifies behavior
+    TestCli ..> CliModule : verifies integration
+```
 
 ## References
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ def test_cli_shows_version(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -107,6 +108,7 @@ def test_cli_accepts_log_level_flag(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--log-level", "debug"])
@@ -340,6 +342,7 @@ def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -390,6 +393,7 @@ def test_cli_uses_explicit_config_path_when_provided(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--config", str(explicit_config)])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -315,6 +315,7 @@ def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):
             extractor="pdfminer",
             fallback_extractor="pdfminer",
             grobid_url="http://localhost:8070",
+            toc_depth=3,
             log_level="INFO",
         )
 
@@ -364,6 +365,7 @@ def test_cli_uses_explicit_config_path_when_provided(tmp_path, monkeypatch):
             extractor="pdfminer",
             fallback_extractor="pdfminer",
             grobid_url="http://localhost:8070",
+            toc_depth=3,
             log_level="INFO",
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from docdown.stages.convert import PandocError
 from docdown.stages.merge import MergeError
 from docdown.stages.split import PdfSplitError
 from docdown.stages.split import PdfValidationError
+from docdown.stages.toc import TocError
 
 
 def test_cli_shows_version(tmp_path, monkeypatch):
@@ -244,6 +245,44 @@ def test_cli_surfaces_merge_errors(tmp_path, monkeypatch):
 
     assert result.exit_code != 0
     assert "merge failed" in result.output
+
+
+def test_cli_surfaces_toc_generation_errors(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path)],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+
+    def _raise_toc_error(*args, **kwargs):
+        raise TocError("toc failed")
+
+    monkeypatch.setattr("docdown.cli.generate_toc", _raise_toc_error)
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "toc failed" in result.output
 
 
 def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,6 +114,18 @@ def test_cli_accepts_log_level_flag(tmp_path, monkeypatch):
     assert result.exit_code == 0
 
 
+def test_cli_rejects_invalid_toc_depth_value(tmp_path):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--toc-depth", "0"])
+
+    assert result.exit_code != 0
+    assert "--toc-depth" in result.output
+    assert "Invalid value" in result.output
+
+
 def test_cli_surfaces_pdf_validation_errors(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_config_defaults_without_file():
     assert cfg.fallback_extractor == "pdfminer"
     assert cfg.table_extraction is True
     assert cfg.llm_cleanup is False
+    assert cfg.toc_depth == 3
     assert cfg.log_level == "INFO"
     assert cfg.validation.min_output_ratio == 0.01
     assert cfg.validation.max_empty_chunks == 0
@@ -44,6 +45,7 @@ def test_config_loads_from_yaml(tmp_path):
                 "table_extraction: false",
                 "llm_cleanup: true",
                 "llm_model: gpt-4o-mini",
+                "toc_depth: 4",
                 "log_level: DEBUG",
                 "validation:",
                 "  min_output_ratio: 0.02",
@@ -65,6 +67,7 @@ def test_config_loads_from_yaml(tmp_path):
     assert cfg.table_extraction is False
     assert cfg.llm_cleanup is True
     assert cfg.llm_model == "gpt-4o-mini"
+    assert cfg.toc_depth == 4
     assert cfg.log_level == "DEBUG"
     assert cfg.validation.min_output_ratio == 0.02
     assert cfg.validation.max_empty_chunks == 1
@@ -78,6 +81,7 @@ def test_cli_overrides_config_values(tmp_path):
                 "workdir: ./from-file",
                 "chunk_size: 100",
                 "parallel_workers: 8",
+                "toc_depth: 6",
                 "log_level: ERROR",
                 "validation:",
                 "  min_output_ratio: 0.05",
@@ -92,6 +96,7 @@ def test_cli_overrides_config_values(tmp_path):
             "workdir": "./from-cli",
             "chunk_size": 20,
             "parallel_workers": 3,
+            "toc_depth": 2,
             "log_level": "debug",
             "validation": {
                 "min_output_ratio": 0.1,
@@ -102,6 +107,7 @@ def test_cli_overrides_config_values(tmp_path):
     assert str(cfg.workdir) == "from-cli"
     assert cfg.chunk_size == 20
     assert cfg.parallel_workers == 3
+    assert cfg.toc_depth == 2
     assert cfg.log_level == "DEBUG"
     assert cfg.validation.min_output_ratio == 0.1
 
@@ -115,6 +121,9 @@ def test_invalid_config_raises_clear_error():
 
     with pytest.raises(ConfigError, match="log_level must be one of"):
         load_config(cli_overrides={"log_level": "VERBOSE"})
+
+    with pytest.raises(ConfigError, match="toc_depth must be between 1 and 6"):
+        load_config(cli_overrides={"toc_depth": 0})
 
 
 def test_string_boolean_values_are_rejected(tmp_path):

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -75,3 +75,21 @@ def test_count_headings_for_toc_respects_depth_and_ignores_fenced_blocks():
 
     assert _count_headings_for_toc(markdown, 3) == 3
     assert _count_headings_for_toc(markdown, 4) == 4
+
+
+def test_count_headings_for_toc_accepts_commonmark_indent_rules():
+    markdown = "\n".join(
+        [
+            "   ## Indented Heading",
+            "    ### Too Indented",
+            "   ```",
+            "   ## Inside Fence",
+            "   ```",
+            "~~~",
+            "## Also Inside Fence",
+            "~~~",
+            " # OneSpaceHeading",
+        ]
+    )
+
+    assert _count_headings_for_toc(markdown, 3) == 2

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -1,0 +1,77 @@
+"""Tests for Stage 6.2 TOC generation."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+from docdown.stages.toc import TocError, _count_headings_for_toc, generate_toc
+
+
+def test_generate_toc_runs_pandoc_and_logs_entry_count(tmp_path, monkeypatch):
+    merged = tmp_path / "merged.md"
+    merged.write_text("# Title\n\n## Intro\n\n### Details\n", encoding="utf-8")
+    final = tmp_path / "final.md"
+
+    def _fake_run(command, capture_output, text, check):
+        assert "--toc" in command
+        assert "--toc-depth=3" in command
+        final.write_text("[TOC]\n\n- [Title](#title)\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("docdown.stages.toc.subprocess.run", _fake_run)
+
+    logger = Mock()
+    output = generate_toc(merged, final, toc_depth=3, logger=logger)
+
+    assert output == final
+    assert final.exists()
+    assert "[TOC]" in final.read_text(encoding="utf-8")
+    logger.info.assert_called_once()
+    assert logger.info.call_args.args[1] == 3
+
+
+def test_generate_toc_copies_merged_when_pandoc_fails(tmp_path, monkeypatch):
+    merged = tmp_path / "merged.md"
+    merged.write_text("# Title\n\n## Intro\n", encoding="utf-8")
+    final = tmp_path / "final.md"
+
+    def _fake_run(command, capture_output, text, check):
+        return subprocess.CompletedProcess(command, 1, "", "conversion failed")
+
+    monkeypatch.setattr("docdown.stages.toc.subprocess.run", _fake_run)
+
+    logger = Mock()
+    output = generate_toc(merged, final, logger=logger)
+
+    assert output == final
+    assert final.read_text(encoding="utf-8") == merged.read_text(encoding="utf-8")
+    logger.warning.assert_called_once()
+    assert logger.info.call_count == 1
+
+
+def test_generate_toc_rejects_invalid_depth(tmp_path):
+    merged = tmp_path / "merged.md"
+    merged.write_text("# Title\n", encoding="utf-8")
+
+    with pytest.raises(TocError, match="toc_depth must be between 1 and 6"):
+        generate_toc(merged, tmp_path / "final.md", toc_depth=0)
+
+
+def test_count_headings_for_toc_respects_depth_and_ignores_fenced_blocks():
+    markdown = "\n".join(
+        [
+            "# One",
+            "## Two",
+            "### Three",
+            "#### Four",
+            "```",
+            "# Not A Heading",
+            "```",
+        ]
+    )
+
+    assert _count_headings_for_toc(markdown, 3) == 3
+    assert _count_headings_for_toc(markdown, 4) == 4


### PR DESCRIPTION
## Summary
- add Stage 6.2 TOC generation module using Pandoc over merged markdown
- write TOC output to inal.md with configurable 	oc_depth (default 3)
- add degraded fallback: copy merged.md to inal.md when Pandoc TOC generation fails
- integrate TOC stage into CLI after merge and surface TOC errors via ClickException
- update Task 6.2 plan doc with implementation notes and artifact class diagram

## Testing
- pytest tests/test_toc.py tests/test_cli.py tests/test_config.py
- pytest
