### PR TITLE
Task 8.2: Final output validation

### DIFF
--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -320,6 +320,7 @@ def main(
             staged_input,
             chunk_results,
             max_empty_chunks=cfg.validation.max_empty_chunks,
+            min_output_ratio=cfg.validation.min_output_ratio,
             logger=logger,
         )
     except FinalValidationError as exc:

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -9,6 +9,7 @@ from docdown.stages.chunk_validation import ChunkResult, validate_chunk
 from docdown.stages.cleanup import CleanupError, cleanup_markdown_file
 from docdown.stages.convert import PandocError, convert_to_markdown, ensure_pandoc_available
 from docdown.stages.extract import ExtractorUsed, orchestrate_extraction
+from docdown.stages.final_validation import FinalValidationError, validate_final_output
 from docdown.stages.merge import MergeError, merge_chunks
 from docdown.stages.split import PdfSplitError, PdfValidationError, split_pdf, validate_pdf
 from docdown.stages.toc import TocError, generate_toc, log_heading_diagnostics
@@ -278,15 +279,6 @@ def main(
         raise click.ClickException("Markdown conversion/cleanup failed for all extracted chunks.")
 
     failed_chunks = [item for item in chunk_results if not item.success]
-    empty_failed_chunks = [
-        item
-        for item in failed_chunks
-        if item.validation is not None and "Empty output" in item.validation.errors
-    ]
-    if len(empty_failed_chunks) > cfg.validation.max_empty_chunks:
-        raise click.ClickException(
-            f"{len(empty_failed_chunks)} empty chunks failed validation (max allowed: {cfg.validation.max_empty_chunks})."
-        )
 
     warning_count = sum(len(item.validation.warnings) for item in chunk_results if item.validation is not None)
     logger.info(
@@ -321,6 +313,28 @@ def main(
         )
     except TocError as exc:
         raise click.ClickException(str(exc)) from exc
+
+    try:
+        final_validation = validate_final_output(
+            work_dir.final_markdown(),
+            staged_input,
+            chunk_results,
+            max_empty_chunks=cfg.validation.max_empty_chunks,
+            logger=logger,
+        )
+    except FinalValidationError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not final_validation.valid:
+        raise click.ClickException(" ; ".join(final_validation.errors))
+
+    logger.info(
+        "Final validation summary: warnings=%s toc_present=%s duplicate_boundaries=%s failed_chunks=%s",
+        len(final_validation.warnings),
+        final_validation.toc_present,
+        final_validation.duplicate_boundary_count,
+        final_validation.failed_chunk_count,
+    )
 
 
 def _version():

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -64,8 +64,9 @@ def validate_final_output(
     except OSError as exc:
         raise FinalValidationError(f"Failed reading source PDF metadata: {exc}") from exc
 
+    toc_scan_lines = 120
     try:
-        final_text = final_markdown.read_text(encoding="utf-8")
+        final_prefix = _read_top_lines(final_markdown, max_lines=toc_scan_lines)
     except OSError as exc:
         raise FinalValidationError(f"Failed reading final markdown: {exc}") from exc
     except UnicodeDecodeError as exc:
@@ -89,7 +90,7 @@ def validate_final_output(
             f"{empty_failed_chunks} empty chunks failed validation (max allowed: {max_empty_chunks})."
         )
 
-    toc_present = _has_toc_near_top(final_text)
+    toc_present = _has_toc_near_top(final_prefix, max_scan_lines=toc_scan_lines)
     if not toc_present:
         warnings.append("Final output appears to be missing a TOC section near the top")
 
@@ -175,3 +176,18 @@ def _normalize_paragraph(text: str) -> str:
 
 def _word_count(text: str) -> int:
     return len(re.findall(r"\S+", text))
+
+
+def _read_top_lines(markdown_path: Path, *, max_lines: int) -> str:
+    if max_lines <= 0:
+        return ""
+
+    lines: list[str] = []
+    with markdown_path.open("r", encoding="utf-8", newline="") as handle:
+        for _ in range(max_lines):
+            line = handle.readline()
+            if not line:
+                break
+            lines.append(line)
+
+    return "".join(lines)

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -9,6 +9,7 @@ import re
 from typing import Iterable
 
 from docdown.stages.chunk_validation import ChunkResult
+from docdown.stages.toc import has_visible_toc_near_top
 from docdown.utils.logging import get_logger
 
 
@@ -121,9 +122,7 @@ def _count_empty_failed_chunks(chunk_results: Iterable[ChunkResult]) -> int:
 
 
 def _has_toc_near_top(markdown_text: str, *, max_scan_lines: int = 120) -> bool:
-    lines = markdown_text.splitlines()[:max_scan_lines]
-    toc_link_pattern = re.compile(r"^\s*-\s+\[[^\]]+\]\([^\)]+\)")
-    return any(toc_link_pattern.search(line) is not None for line in lines)
+    return has_visible_toc_near_top(markdown_text, max_scan_lines=max_scan_lines)
 
 
 def _detect_duplicate_boundaries(chunk_results: Iterable[ChunkResult], *, logger: LogLike) -> list[str]:

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -165,11 +165,17 @@ def _read_chunk_boundary_paragraphs(markdown_path: Path | None, *, logger: LogLi
         return None, None
 
     paragraphs = [_normalize_paragraph(part) for part in re.split(r"\n\s*\n", text)]
-    candidates = [paragraph for paragraph in paragraphs if _word_count(paragraph) > 50]
-    if not candidates:
+    non_empty_paragraphs = [paragraph for paragraph in paragraphs if paragraph]
+    if not non_empty_paragraphs:
         return None, None
 
-    return candidates[-1], candidates[0]
+    first_paragraph = non_empty_paragraphs[0]
+    last_paragraph = non_empty_paragraphs[-1]
+
+    first_boundary = first_paragraph if _word_count(first_paragraph) > 50 else None
+    last_boundary = last_paragraph if _word_count(last_paragraph) > 50 else None
+
+    return last_boundary, first_boundary
 
 
 def _normalize_paragraph(text: str) -> str:

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -1,0 +1,178 @@
+"""Stage 8.2 - Final markdown output validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import re
+from typing import Iterable
+
+from docdown.stages.chunk_validation import ChunkResult
+from docdown.utils.logging import get_logger
+
+
+LogLike = logging.Logger | logging.LoggerAdapter
+
+
+class FinalValidationError(ValueError):
+    """Raised when final output validation cannot be completed."""
+
+
+@dataclass(frozen=True)
+class FinalValidationResult:
+    """Validation outcome for the final markdown artifact."""
+
+    valid: bool
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+    failed_chunk_count: int
+    toc_present: bool
+    duplicate_boundary_count: int
+
+
+def validate_final_output(
+    final_path: Path,
+    source_pdf_path: Path,
+    chunk_results: Iterable[ChunkResult],
+    *,
+    max_empty_chunks: int,
+    logger: LogLike | None = None,
+) -> FinalValidationResult:
+    """Validate final markdown output and return aggregated findings."""
+
+    if max_empty_chunks < 0:
+        raise ValueError(f"max_empty_chunks must be >= 0, got {max_empty_chunks}")
+
+    active_logger = logger or get_logger()
+    final_markdown = Path(final_path)
+    source_pdf = Path(source_pdf_path)
+
+    if not final_markdown.exists() or not final_markdown.is_file():
+        raise FinalValidationError(f"Final markdown output not found: {final_markdown}")
+    if not source_pdf.exists() or not source_pdf.is_file():
+        raise FinalValidationError(f"Source PDF not found: {source_pdf}")
+
+    try:
+        final_size = final_markdown.stat().st_size
+    except OSError as exc:
+        raise FinalValidationError(f"Failed reading final markdown metadata: {exc}") from exc
+
+    try:
+        source_size = source_pdf.stat().st_size
+    except OSError as exc:
+        raise FinalValidationError(f"Failed reading source PDF metadata: {exc}") from exc
+
+    try:
+        final_text = final_markdown.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise FinalValidationError(f"Failed reading final markdown: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise FinalValidationError(f"Failed reading final markdown: invalid UTF-8 encoding ({exc})") from exc
+
+    result_items = sorted(chunk_results, key=lambda item: item.chunk_number)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if source_size > 0:
+        ratio = final_size / source_size
+        if ratio < 0.01:
+            warnings.append(
+                f"Final output ratio {ratio:.4f} below threshold 0.0100"
+            )
+
+    empty_failed_chunks = _count_empty_failed_chunks(result_items)
+    if empty_failed_chunks > max_empty_chunks:
+        errors.append(
+            f"{empty_failed_chunks} empty chunks failed validation (max allowed: {max_empty_chunks})."
+        )
+
+    toc_present = _has_toc_near_top(final_text)
+    if not toc_present:
+        warnings.append("Final output appears to be missing a TOC section near the top")
+
+    duplicate_warnings = _detect_duplicate_boundaries(result_items, logger=active_logger)
+    warnings.extend(duplicate_warnings)
+
+    for issue in errors:
+        active_logger.error("Final validation failed: %s", issue)
+    for warning in warnings:
+        active_logger.warning("Final validation warning: %s", warning)
+
+    return FinalValidationResult(
+        valid=not errors,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+        failed_chunk_count=sum(1 for item in result_items if not item.success),
+        toc_present=toc_present,
+        duplicate_boundary_count=len(duplicate_warnings),
+    )
+
+
+def _count_empty_failed_chunks(chunk_results: Iterable[ChunkResult]) -> int:
+    empty_count = 0
+    for result in chunk_results:
+        if result.success:
+            continue
+        if result.validation is not None and "Empty output" in result.validation.errors:
+            empty_count += 1
+    return empty_count
+
+
+def _has_toc_near_top(markdown_text: str, *, max_scan_lines: int = 120) -> bool:
+    lines = markdown_text.splitlines()[:max_scan_lines]
+    toc_link_pattern = re.compile(r"^\s*-\s+\[[^\]]+\]\([^\)]+\)")
+    return any(toc_link_pattern.search(line) is not None for line in lines)
+
+
+def _detect_duplicate_boundaries(chunk_results: Iterable[ChunkResult], *, logger: LogLike) -> list[str]:
+    warnings: list[str] = []
+    chunk_list = list(chunk_results)
+    for left, right in zip(chunk_list, chunk_list[1:]):
+        left_paragraph = _read_boundary_paragraph(left.markdown_path, from_end=True, logger=logger)
+        right_paragraph = _read_boundary_paragraph(right.markdown_path, from_end=False, logger=logger)
+        if left_paragraph is None or right_paragraph is None:
+            continue
+        if left_paragraph == right_paragraph:
+            warnings.append(
+                "Potential duplicate boundary paragraph between "
+                f"chunk-{left.chunk_number:04d} and chunk-{right.chunk_number:04d}"
+            )
+    return warnings
+
+
+def _read_boundary_paragraph(
+    markdown_path: Path | None,
+    *,
+    from_end: bool,
+    logger: LogLike,
+) -> str | None:
+    if markdown_path is None:
+        return None
+
+    path = Path(markdown_path)
+    if not path.exists() or not path.is_file():
+        return None
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Final validation skipped unreadable chunk markdown %s: %s", path, exc)
+        return None
+
+    paragraphs = [_normalize_paragraph(part) for part in re.split(r"\n\s*\n", text)]
+    candidates = [paragraph for paragraph in paragraphs if _word_count(paragraph) > 50]
+    if not candidates:
+        return None
+
+    return candidates[-1] if from_end else candidates[0]
+
+
+def _normalize_paragraph(text: str) -> str:
+    collapsed = re.sub(r"\s+", " ", text.strip())
+    return collapsed
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\S+", text))

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -129,9 +129,14 @@ def _has_toc_near_top(markdown_text: str, *, max_scan_lines: int = 120) -> bool:
 def _detect_duplicate_boundaries(chunk_results: Iterable[ChunkResult], *, logger: LogLike) -> list[str]:
     warnings: list[str] = []
     chunk_list = list(chunk_results)
+    boundary_cache = {
+        chunk.chunk_number: _read_chunk_boundary_paragraphs(chunk.markdown_path, logger=logger)
+        for chunk in chunk_list
+    }
+
     for left, right in zip(chunk_list, chunk_list[1:]):
-        left_paragraph = _read_boundary_paragraph(left.markdown_path, from_end=True, logger=logger)
-        right_paragraph = _read_boundary_paragraph(right.markdown_path, from_end=False, logger=logger)
+        left_paragraph, _ = boundary_cache[left.chunk_number]
+        _, right_paragraph = boundary_cache[right.chunk_number]
         if left_paragraph is None or right_paragraph is None:
             continue
         if left_paragraph == right_paragraph:
@@ -167,6 +172,28 @@ def _read_boundary_paragraph(
         return None
 
     return candidates[-1] if from_end else candidates[0]
+
+
+def _read_chunk_boundary_paragraphs(markdown_path: Path | None, *, logger: LogLike) -> tuple[str | None, str | None]:
+    if markdown_path is None:
+        return None, None
+
+    path = Path(markdown_path)
+    if not path.exists() or not path.is_file():
+        return None, None
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Final validation skipped unreadable chunk markdown %s: %s", path, exc)
+        return None, None
+
+    paragraphs = [_normalize_paragraph(part) for part in re.split(r"\n\s*\n", text)]
+    candidates = [paragraph for paragraph in paragraphs if _word_count(paragraph) > 50]
+    if not candidates:
+        return None, None
+
+    return candidates[-1], candidates[0]
 
 
 def _normalize_paragraph(text: str) -> str:

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import math
 from pathlib import Path
 import re
 from typing import Iterable
@@ -38,12 +39,15 @@ def validate_final_output(
     chunk_results: Iterable[ChunkResult],
     *,
     max_empty_chunks: int,
+    min_output_ratio: float = 0.01,
     logger: LogLike | None = None,
 ) -> FinalValidationResult:
     """Validate final markdown output and return aggregated findings."""
 
     if max_empty_chunks < 0:
         raise ValueError(f"max_empty_chunks must be >= 0, got {max_empty_chunks}")
+    if not math.isfinite(min_output_ratio) or min_output_ratio <= 0:
+        raise ValueError(f"min_output_ratio must be > 0 and finite, got {min_output_ratio}")
 
     active_logger = logger or get_logger()
     final_markdown = Path(final_path)
@@ -79,9 +83,9 @@ def validate_final_output(
 
     if source_size > 0:
         ratio = final_size / source_size
-        if ratio < 0.01:
+        if ratio < min_output_ratio:
             warnings.append(
-                f"Final output ratio {ratio:.4f} below threshold 0.0100"
+                f"Final output ratio {ratio:.4f} below threshold {min_output_ratio:.4f}"
             )
 
     empty_failed_chunks = _count_empty_failed_chunks(result_items)

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -128,13 +128,16 @@ def _has_toc_near_top(markdown_text: str, *, max_scan_lines: int = 120) -> bool:
 
 def _detect_duplicate_boundaries(chunk_results: Iterable[ChunkResult], *, logger: LogLike) -> list[str]:
     warnings: list[str] = []
-    chunk_list = list(chunk_results)
+    chunk_list = sorted(chunk_results, key=lambda chunk: chunk.chunk_number)
     boundary_cache = {
         chunk.chunk_number: _read_chunk_boundary_paragraphs(chunk.markdown_path, logger=logger)
         for chunk in chunk_list
     }
 
     for left, right in zip(chunk_list, chunk_list[1:]):
+        if right.chunk_number != left.chunk_number + 1:
+            continue
+
         left_paragraph, _ = boundary_cache[left.chunk_number]
         _, right_paragraph = boundary_cache[right.chunk_number]
         if left_paragraph is None or right_paragraph is None:

--- a/docdown/stages/final_validation.py
+++ b/docdown/stages/final_validation.py
@@ -147,33 +147,6 @@ def _detect_duplicate_boundaries(chunk_results: Iterable[ChunkResult], *, logger
     return warnings
 
 
-def _read_boundary_paragraph(
-    markdown_path: Path | None,
-    *,
-    from_end: bool,
-    logger: LogLike,
-) -> str | None:
-    if markdown_path is None:
-        return None
-
-    path = Path(markdown_path)
-    if not path.exists() or not path.is_file():
-        return None
-
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
-        logger.warning("Final validation skipped unreadable chunk markdown %s: %s", path, exc)
-        return None
-
-    paragraphs = [_normalize_paragraph(part) for part in re.split(r"\n\s*\n", text)]
-    candidates = [paragraph for paragraph in paragraphs if _word_count(paragraph) > 50]
-    if not candidates:
-        return None
-
-    return candidates[-1] if from_end else candidates[0]
-
-
 def _read_chunk_boundary_paragraphs(markdown_path: Path | None, *, logger: LogLike) -> tuple[str | None, str | None]:
     if markdown_path is None:
         return None, None

--- a/docdown/stages/toc.py
+++ b/docdown/stages/toc.py
@@ -332,6 +332,12 @@ def _count_visible_toc_entries_near_top(markdown_text: str, *, max_scan_lines: i
     return 0
 
 
+def has_visible_toc_near_top(markdown_text: str, *, max_scan_lines: int = 120) -> bool:
+    """Return True when a TOC-like anchor list is visible near the top of markdown."""
+
+    return _count_visible_toc_entries_near_top(markdown_text, max_scan_lines=max_scan_lines) > 0
+
+
 def _build_python_toc_block(entries: list[tuple[int, str, str]]) -> str:
     if not entries:
         return ""

--- a/docs/plan/task-8.2-final-validation.md
+++ b/docs/plan/task-8.2-final-validation.md
@@ -11,8 +11,8 @@ Validate the merged final Markdown output for completeness and structural integr
 ## Acceptance Criteria
 
 - [x] `final.md` file size is checked: if < 1% of source PDF size, log a warning.
-- [x] Failed chunk count is checked against `max_empty_chunks` config; if exceeded, abort.
-- [x] TOC presence is verified (at least one `- [` link pattern at the top of the file).
+- [x] Empty-output chunk failures are checked against `max_empty_chunks`; if exceeded, abort.
+- [x] TOC presence is verified using the TOC-stage visibility heuristics near the top of the file (internal `(#...)` anchor links, `-`/`*` bullets, and marker-aware entry counting).
 - [x] Duplicate content detection: identical paragraphs (>50 words) in adjacent chunk boundaries are flagged.
 - [x] All validation results are collected for the run summary.
 - [x] Unit tests cover each check.
@@ -40,11 +40,24 @@ def validate_final(final_path, source_pdf_path, chunk_results, config):
 ### Failed chunk threshold
 
 ```python
-    failed_count = sum(1 for r in chunk_results if not r.success)
-    if failed_count > config.validation.max_empty_chunks:
+    empty_failed_count = sum(
+        1
+        for r in chunk_results
+        if not r.success and r.validation and "Empty output" in r.validation.errors
+    )
+    if empty_failed_count > config.validation.max_empty_chunks:
         raise FatalPipelineError(
-            f"{failed_count} chunks failed (max allowed: {config.validation.max_empty_chunks})"
+            f"{empty_failed_count} empty chunks failed (max allowed: {config.validation.max_empty_chunks})"
         )
+```
+
+### TOC presence check
+
+```python
+    # Reuse the same visibility logic as Stage 6.2 TOC checks.
+    toc_present = has_visible_toc_near_top(final_prefix, max_scan_lines=120)
+    if not toc_present:
+        warnings.append("Final output appears to be missing a TOC section near the top")
 ```
 
 ### Duplicate detection

--- a/docs/plan/task-8.2-final-validation.md
+++ b/docs/plan/task-8.2-final-validation.md
@@ -10,12 +10,18 @@ Validate the merged final Markdown output for completeness and structural integr
 
 ## Acceptance Criteria
 
-- [ ] `final.md` file size is checked: if < 1% of source PDF size, log a warning.
-- [ ] Failed chunk count is checked against `max_empty_chunks` config; if exceeded, abort.
-- [ ] TOC presence is verified (at least one `- [` link pattern at the top of the file).
-- [ ] Duplicate content detection: identical paragraphs (>50 words) in adjacent chunk boundaries are flagged.
-- [ ] All validation results are collected for the run summary.
-- [ ] Unit tests cover each check.
+- [x] `final.md` file size is checked: if < 1% of source PDF size, log a warning.
+- [x] Failed chunk count is checked against `max_empty_chunks` config; if exceeded, abort.
+- [x] TOC presence is verified (at least one `- [` link pattern at the top of the file).
+- [x] Duplicate content detection: identical paragraphs (>50 words) in adjacent chunk boundaries are flagged.
+- [x] All validation results are collected for the run summary.
+- [x] Unit tests cover each check.
+
+Implemented in:
+- `docdown/stages/final_validation.py`
+- `docdown/cli.py`
+- `tests/test_final_validation.py`
+- `tests/test_cli.py`
 
 ## Implementation Notes
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,20 @@ from click.testing import CliRunner
 from docdown import __version__
 from docdown.cli import main
 from docdown.stages.convert import PandocError
+from docdown.stages.final_validation import FinalValidationError
 from docdown.stages.merge import MergeError
 from docdown.stages.split import PdfSplitError
 from docdown.stages.split import PdfValidationError
 from docdown.stages.toc import TocError
+
+
+def _fake_generate_toc(merged_path, final_path, **kwargs):
+    _ = merged_path
+    _ = kwargs
+    final = Path(final_path)
+    final.parent.mkdir(parents=True, exist_ok=True)
+    final.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+    return final
 
 
 def test_cli_shows_version(tmp_path, monkeypatch):
@@ -44,7 +54,7 @@ def test_cli_shows_version(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -108,7 +118,7 @@ def test_cli_accepts_log_level_flag(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--log-level", "debug"])
@@ -272,7 +282,7 @@ def test_cli_continues_when_cleanup_hits_invalid_utf8_for_one_chunk(tmp_path, mo
         "docdown.cli.validate_chunk",
         lambda *args, **kwargs: SimpleNamespace(valid=True, warnings=(), errors=()),
     )
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -393,7 +403,7 @@ def test_cli_continues_when_chunk_validation_warns(tmp_path, monkeypatch):
         "docdown.cli.validate_chunk",
         lambda *args, **kwargs: SimpleNamespace(valid=True, warnings=("No headings detected",), errors=()),
     )
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -481,6 +491,7 @@ def test_cli_enforces_max_empty_chunks_threshold(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     def _fake_validate_chunk(*args, **kwargs):
         if kwargs["chunk_number"] == 1:
@@ -547,7 +558,7 @@ def test_cli_does_not_count_non_empty_validation_failures_toward_max_empty_chunk
         return SimpleNamespace(valid=True, warnings=(), errors=())
 
     monkeypatch.setattr("docdown.cli.validate_chunk", _fake_validate_chunk)
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -611,6 +622,45 @@ def test_cli_fails_fast_on_non_recoverable_chunk_validation_errors(tmp_path, mon
     assert "Markdown output is not a file" in result.output
 
 
+def test_cli_surfaces_final_validation_errors(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_path = tmp_path / "out" / "extracted" / "chunk-0001.xml"
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=1, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(chunk_count=1, chunk_paths=(tmp_path / "out" / "chunks" / "chunk-0001.pdf",)),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [SimpleNamespace(chunk_number=1, success=True, output_path=extracted_path, extractor="grobid")],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
+
+    def _raise_final_validation_error(*args, **kwargs):
+        raise FinalValidationError("final validation failed")
+
+    monkeypatch.setattr("docdown.cli.validate_final_output", _raise_final_validation_error)
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code != 0
+    assert "final validation failed" in result.output
+
+
 def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
@@ -658,7 +708,7 @@ def test_cli_autoloads_repo_config_when_flag_omitted(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
@@ -713,7 +763,7 @@ def test_cli_uses_explicit_config_path_when_provided(tmp_path, monkeypatch):
         return Path(output_path)
 
     monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
-    monkeypatch.setattr("docdown.cli.generate_toc", lambda *args, **kwargs: Path(args[1]))
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
 
     runner = CliRunner()
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out"), "--config", str(explicit_config)])

--- a/tests/test_final_validation.py
+++ b/tests/test_final_validation.py
@@ -1,0 +1,124 @@
+"""Tests for Stage 8.2 final output validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from docdown.stages.chunk_validation import ChunkResult, ChunkValidationResult
+from docdown.stages.final_validation import validate_final_output
+
+
+def _chunk_result(
+    chunk_number: int,
+    markdown_path: Path,
+    *,
+    success: bool = True,
+    error: str | None = None,
+    validation_errors: tuple[str, ...] = (),
+) -> ChunkResult:
+    validation = ChunkValidationResult(
+        valid=not validation_errors,
+        errors=validation_errors,
+        warnings=(),
+    )
+    return ChunkResult(
+        chunk_number=chunk_number,
+        success=success,
+        markdown_path=markdown_path,
+        error=error,
+        validation=validation,
+    )
+
+
+def test_validate_final_output_warns_when_final_is_too_small(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 10000)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    chunk_path = tmp_path / "chunk-0001.md"
+    chunk_path.write_text("# Heading\n\nBody\n", encoding="utf-8")
+    chunk_results = [_chunk_result(1, chunk_path)]
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        chunk_results,
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert any("Final output ratio" in warning for warning in result.warnings)
+
+
+def test_validate_final_output_fails_when_empty_chunk_failures_exceed_threshold(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    chunk_path = tmp_path / "chunk-0001.md"
+    chunk_path.write_text("# Heading\n\nBody\n", encoding="utf-8")
+    chunk_results = [
+        _chunk_result(1, chunk_path, success=False, error="empty", validation_errors=("Empty output",)),
+        _chunk_result(2, chunk_path, success=True),
+    ]
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        chunk_results,
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is False
+    assert result.errors == ("1 empty chunks failed validation (max allowed: 0).",)
+
+
+def test_validate_final_output_warns_when_toc_links_missing_near_top(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("# Heading\n\nNo TOC links here.\n", encoding="utf-8")
+
+    chunk_path = tmp_path / "chunk-0001.md"
+    chunk_path.write_text("# Heading\n\nBody\n", encoding="utf-8")
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_path)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert "Final output appears to be missing a TOC section near the top" in result.warnings
+
+
+def test_validate_final_output_flags_duplicate_boundary_paragraph(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    repeated_paragraph = " ".join(["word"] * 51)
+    chunk_1 = tmp_path / "chunk-0001.md"
+    chunk_2 = tmp_path / "chunk-0002.md"
+    chunk_1.write_text(f"# Heading\n\nIntro\n\n{repeated_paragraph}\n", encoding="utf-8")
+    chunk_2.write_text(f"{repeated_paragraph}\n\nMore text\n", encoding="utf-8")
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_1), _chunk_result(2, chunk_2)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert result.duplicate_boundary_count == 1
+    assert any("Potential duplicate boundary paragraph" in warning for warning in result.warnings)

--- a/tests/test_final_validation.py
+++ b/tests/test_final_validation.py
@@ -232,3 +232,34 @@ def test_validate_final_output_skips_duplicate_check_across_missing_chunk_number
     assert result.valid is True
     assert result.duplicate_boundary_count == 0
     assert not any("Potential duplicate boundary paragraph" in warning for warning in result.warnings)
+
+
+def test_validate_final_output_ignores_matching_interior_paragraphs_when_boundaries_are_short(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    repeated_interior = " ".join(["word"] * 51)
+    chunk_1 = tmp_path / "chunk-0001.md"
+    chunk_2 = tmp_path / "chunk-0002.md"
+    chunk_1.write_text(
+        "# H1\n\nshort start\n\n" + repeated_interior + "\n\nshort end\n",
+        encoding="utf-8",
+    )
+    chunk_2.write_text(
+        "short start\n\n" + repeated_interior + "\n\n# H2\n\nshort end\n",
+        encoding="utf-8",
+    )
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_1), _chunk_result(2, chunk_2)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert result.duplicate_boundary_count == 0
+    assert not any("Potential duplicate boundary paragraph" in warning for warning in result.warnings)

--- a/tests/test_final_validation.py
+++ b/tests/test_final_validation.py
@@ -170,3 +170,40 @@ def test_validate_final_output_flags_duplicate_boundary_paragraph(tmp_path):
     assert result.valid is True
     assert result.duplicate_boundary_count == 1
     assert any("Potential duplicate boundary paragraph" in warning for warning in result.warnings)
+
+
+def test_validate_final_output_reads_each_chunk_once_for_boundary_checks(tmp_path, monkeypatch):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    repeated_paragraph = " ".join(["word"] * 51)
+    chunk_1 = tmp_path / "chunk-0001.md"
+    chunk_2 = tmp_path / "chunk-0002.md"
+    chunk_3 = tmp_path / "chunk-0003.md"
+    chunk_1.write_text(f"# H1\n\n{repeated_paragraph}\n", encoding="utf-8")
+    chunk_2.write_text(f"# H2\n\n{repeated_paragraph}\n", encoding="utf-8")
+    chunk_3.write_text("# H3\n\nunique words only\n", encoding="utf-8")
+
+    read_counts: dict[Path, int] = {chunk_1: 0, chunk_2: 0, chunk_3: 0}
+    original_read_text = Path.read_text
+
+    def _count_reads(self, *args, **kwargs):
+        if self in read_counts:
+            read_counts[self] += 1
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _count_reads)
+
+    validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_1), _chunk_result(2, chunk_2), _chunk_result(3, chunk_3)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert read_counts[chunk_1] == 1
+    assert read_counts[chunk_2] == 1
+    assert read_counts[chunk_3] == 1

--- a/tests/test_final_validation.py
+++ b/tests/test_final_validation.py
@@ -207,3 +207,28 @@ def test_validate_final_output_reads_each_chunk_once_for_boundary_checks(tmp_pat
     assert read_counts[chunk_1] == 1
     assert read_counts[chunk_2] == 1
     assert read_counts[chunk_3] == 1
+
+
+def test_validate_final_output_skips_duplicate_check_across_missing_chunk_numbers(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    repeated_paragraph = " ".join(["word"] * 51)
+    chunk_1 = tmp_path / "chunk-0001.md"
+    chunk_3 = tmp_path / "chunk-0003.md"
+    chunk_1.write_text(f"# H1\n\n{repeated_paragraph}\n", encoding="utf-8")
+    chunk_3.write_text(f"{repeated_paragraph}\n\n# H3\n", encoding="utf-8")
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_1), _chunk_result(3, chunk_3)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert result.duplicate_boundary_count == 0
+    assert not any("Potential duplicate boundary paragraph" in warning for warning in result.warnings)

--- a/tests/test_final_validation.py
+++ b/tests/test_final_validation.py
@@ -53,6 +53,31 @@ def test_validate_final_output_warns_when_final_is_too_small(tmp_path):
     assert any("Final output ratio" in warning for warning in result.warnings)
 
 
+def test_validate_final_output_uses_configurable_min_output_ratio(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text("- [Section](#section)\n\n# Section\n", encoding="utf-8")
+
+    chunk_path = tmp_path / "chunk-0001.md"
+    chunk_path.write_text("# Heading\n\nBody\n", encoding="utf-8")
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_path)],
+        max_empty_chunks=0,
+        min_output_ratio=0.5,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert any(
+        warning.startswith("Final output ratio ") and "below threshold 0.5000" in warning
+        for warning in result.warnings
+    )
+
+
 def test_validate_final_output_fails_when_empty_chunk_failures_exceed_threshold(tmp_path):
     source_pdf = tmp_path / "source.pdf"
     source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)

--- a/tests/test_final_validation.py
+++ b/tests/test_final_validation.py
@@ -99,6 +99,54 @@ def test_validate_final_output_warns_when_toc_links_missing_near_top(tmp_path):
     assert "Final output appears to be missing a TOC section near the top" in result.warnings
 
 
+def test_validate_final_output_does_not_treat_external_link_list_as_toc(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text(
+        "## Resources\n\n- [Website](https://example.com)\n- [Repo](https://github.com/example/repo)\n\n# Heading\n",
+        encoding="utf-8",
+    )
+
+    chunk_path = tmp_path / "chunk-0001.md"
+    chunk_path.write_text("# Heading\n\nBody\n", encoding="utf-8")
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_path)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert "Final output appears to be missing a TOC section near the top" in result.warnings
+
+
+def test_validate_final_output_accepts_star_bullet_anchor_toc(tmp_path):
+    source_pdf = tmp_path / "source.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)
+    final_md = tmp_path / "final.md"
+    final_md.write_text(
+        "## Table of Contents\n\n* [Intro](#intro)\n\n# Intro\n",
+        encoding="utf-8",
+    )
+
+    chunk_path = tmp_path / "chunk-0001.md"
+    chunk_path.write_text("# Intro\n\nBody\n", encoding="utf-8")
+
+    result = validate_final_output(
+        final_md,
+        source_pdf,
+        [_chunk_result(1, chunk_path)],
+        max_empty_chunks=0,
+        logger=Mock(),
+    )
+
+    assert result.valid is True
+    assert "Final output appears to be missing a TOC section near the top" not in result.warnings
+
+
 def test_validate_final_output_flags_duplicate_boundary_paragraph(tmp_path):
     source_pdf = tmp_path / "source.pdf"
     source_pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 100)


### PR DESCRIPTION
## Summary
- add Stage 8.2 final output validation module for final markdown checks
- integrate final validation into CLI after TOC generation
- validate final output size ratio, TOC presence near top, duplicate boundary paragraphs, and empty-failed chunk threshold
- update Task 8.2 plan checklist and add targeted CLI/final-validation tests

## Testing
- pytest tests/test_final_validation.py tests/test_cli.py tests/test_chunk_validation.py tests/test_merge.py tests/test_toc.py -q
- result: 60 passed