### PR TITLE
Task 10.1: add CI and CD workflows aligned with 10.0 deployment contract

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,7 +69,15 @@ jobs:
 
           python3 -m venv "${release_dir}/.venv"
           "${release_dir}/.venv/bin/pip" install --upgrade pip
-          "${release_dir}/.venv/bin/pip" install "${release_dir}"
+
+          wheelhouse_dir="${DOCDOWN_SHARED_DIR}/wheelhouse"
+          if [ -d "${wheelhouse_dir}" ] && find "${wheelhouse_dir}" -maxdepth 1 -type f \( -name '*.whl' -o -name '*.tar.gz' \) | grep -q .; then
+            echo "Installing from local wheelhouse: ${wheelhouse_dir}"
+            "${release_dir}/.venv/bin/pip" install --no-index --find-links "${wheelhouse_dir}" "${release_dir}"
+          else
+            echo "Warning: wheelhouse not found/empty at ${wheelhouse_dir}; installing from package index." >&2
+            "${release_dir}/.venv/bin/pip" install "${release_dir}"
+          fi
 
           sudo /usr/local/bin/docdown-activate-release "${release_dir}"
           sudo /usr/bin/systemctl restart docdown-worker
@@ -154,6 +162,7 @@ jobs:
           - user: docdown-runner
           - python: python3 must resolve to >= 3.10 with venv support (python3-venv)
           - system tools: qpdf, pandoc, ghostscript
+          - optional for reproducible/offline deploys: populate /opt/docdown/shared/wheelhouse with dependency wheels
           - writable paths: /opt/docdown, /opt/docdown/releases, /opt/docdown/shared, /opt/docdown/workspace
           - privileged commands:
             * /usr/local/bin/docdown-activate-release <release-path>

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -107,9 +107,20 @@ jobs:
           set -euo pipefail
 
           if [ -n "${PREVIOUS_RELEASE:-}" ] && [ -d "${PREVIOUS_RELEASE}" ]; then
+            echo "Rollback: restoring previous release ${PREVIOUS_RELEASE}"
             sudo /usr/local/bin/docdown-activate-release "${PREVIOUS_RELEASE}"
             sudo /usr/bin/systemctl restart docdown-worker
             sudo /usr/bin/systemctl restart docdown-api
+            if [ -L "${DOCDOWN_CURRENT_LINK}" ]; then
+              echo "Rollback complete. Current link target: $(readlink -f "${DOCDOWN_CURRENT_LINK}" || true)"
+            fi
+          else
+            echo "Rollback skipped: PREVIOUS_RELEASE is empty or does not exist (${PREVIOUS_RELEASE:-<empty>})."
+            if [ -L "${DOCDOWN_CURRENT_LINK}" ]; then
+              echo "Current link target: $(readlink -f "${DOCDOWN_CURRENT_LINK}" || true)"
+            else
+              echo "Current link is not a symlink: ${DOCDOWN_CURRENT_LINK}"
+            fi
           fi
 
       - name: Deployment prerequisites

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,26 +79,33 @@ jobs:
           test -s "${smoke_output_dir}/final.md"
           grep -q "Run Summary" "${smoke_log}"
 
-          if [ -n "${previous_release}" ] && [ -d "${previous_release}" ]; then
-            # Keep the 5 newest release directories; remove older ones safely.
-            find "${DOCDOWN_RELEASES_DIR}" \
-              -mindepth 1 \
-              -maxdepth 1 \
-              -type d \
-              -printf '%T@\t%p\0' | sort -z -n -r |
-              {
-                keep=0
-                while IFS= read -r -d '' entry; do
-                  keep=$((keep + 1))
-                  if [ "${keep}" -le 5 ]; then
-                    continue
-                  fi
-
-                  release_path="${entry#*$'\t'}"
-                  rm -rf -- "${release_path}"
-                done
-              }
+          current_release=""
+          if [ -L "${DOCDOWN_CURRENT_LINK}" ]; then
+            current_release="$(readlink -f "${DOCDOWN_CURRENT_LINK}" || true)"
           fi
+
+          # Keep the 5 newest release directories; remove older ones safely.
+          find "${DOCDOWN_RELEASES_DIR}" \
+            -mindepth 1 \
+            -maxdepth 1 \
+            -type d \
+            -printf '%T@\t%p\0' | sort -z -n -r |
+            {
+              keep=0
+              while IFS= read -r -d '' entry; do
+                keep=$((keep + 1))
+                if [ "${keep}" -le 5 ]; then
+                  continue
+                fi
+
+                release_path="${entry#*$'\t'}"
+                if [ -n "${current_release}" ] && [ "${release_path}" = "${current_release}" ]; then
+                  continue
+                fi
+
+                rm -rf -- "${release_path}"
+              done
+            }
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
           previous_release=""
 
           if [ -L "${DOCDOWN_CURRENT_LINK}" ]; then
-            previous_release="$(readlink -f "${DOCDOWN_CURRENT_LINK}")"
+            previous_release="$(readlink -f "${DOCDOWN_CURRENT_LINK}" || true)"
           fi
 
           echo "PREVIOUS_RELEASE=${previous_release}" >> "${GITHUB_ENV}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,7 +77,24 @@ jobs:
           grep -q "Run Summary" "${smoke_log}"
 
           if [ -n "${previous_release}" ] && [ -d "${previous_release}" ]; then
-            ls -1dt "${DOCDOWN_RELEASES_DIR}"/* | tail -n +6 | xargs -r rm -rf
+            # Keep the 5 newest release directories; remove older ones safely.
+            find "${DOCDOWN_RELEASES_DIR}" \
+              -mindepth 1 \
+              -maxdepth 1 \
+              -type d \
+              -printf '%T@\t%p\0' | sort -z -n -r |
+              {
+                keep=0
+                while IFS= read -r -d '' entry; do
+                  keep=$((keep + 1))
+                  if [ "${keep}" -le 5 ]; then
+                    continue
+                  fi
+
+                  release_path="${entry#*$'\t'}"
+                  rm -rf -- "${release_path}"
+                done
+              }
           fi
 
       - name: Roll back on failure

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,6 +64,7 @@ jobs:
 
           smoke_output_dir="${DOCDOWN_SHARED_DIR}/smoke/output"
           smoke_log="${smoke_output_dir}/run.log"
+          smoke_stderr_log="${smoke_output_dir}/stderr.log"
 
           rm -rf "${smoke_output_dir}"
           mkdir -p "${smoke_output_dir}"
@@ -71,7 +72,7 @@ jobs:
             "${DOCDOWN_SHARED_DIR}/smoke/input.pdf" \
             -o "${smoke_output_dir}" \
             --log-level INFO \
-            2> >(tee "${smoke_log}" >&2)
+            2> >(tee "${smoke_stderr_log}" >&2)
 
           test -s "${smoke_output_dir}/final.md"
           grep -q "Run Summary" "${smoke_log}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,113 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: docdown-cd-main
+  cancel-in-progress: false
+
+env:
+  DOCDOWN_DEPLOY_ROOT: /opt/docdown
+  DOCDOWN_RELEASES_DIR: /opt/docdown/releases
+  DOCDOWN_CURRENT_LINK: /opt/docdown/current
+  DOCDOWN_SHARED_DIR: /opt/docdown/shared
+  DOCDOWN_WORKSPACE_DIR: /opt/docdown/workspace
+
+jobs:
+  deploy:
+    name: Deploy to local runner
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - docdown
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare release, activate, and verify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_id="$(date -u +%Y%m%d%H%M%S)-${GITHUB_SHA::7}"
+          release_dir="${DOCDOWN_RELEASES_DIR}/${release_id}"
+          previous_release=""
+
+          if [ -L "${DOCDOWN_CURRENT_LINK}" ]; then
+            previous_release="$(readlink -f "${DOCDOWN_CURRENT_LINK}")"
+          fi
+
+          echo "PREVIOUS_RELEASE=${previous_release}" >> "${GITHUB_ENV}"
+
+          mkdir -p "${DOCDOWN_RELEASES_DIR}" "${DOCDOWN_SHARED_DIR}" "${DOCDOWN_WORKSPACE_DIR}"
+          rm -rf "${DOCDOWN_WORKSPACE_DIR}/repo"
+          cp -a "${GITHUB_WORKSPACE}" "${DOCDOWN_WORKSPACE_DIR}/repo"
+          rm -rf "${DOCDOWN_WORKSPACE_DIR}/repo/.git"
+
+          mkdir -p "${release_dir}"
+          cp -a "${DOCDOWN_WORKSPACE_DIR}/repo/." "${release_dir}/"
+
+          python3 -m venv "${release_dir}/.venv"
+          "${release_dir}/.venv/bin/pip" install --upgrade pip
+          "${release_dir}/.venv/bin/pip" install "${release_dir}"
+
+          sudo /usr/local/bin/docdown-activate-release "${release_dir}"
+          sudo systemctl restart docdown-worker
+          sudo systemctl restart docdown-api
+
+          smoke_output_dir="${DOCDOWN_SHARED_DIR}/smoke/output"
+          smoke_log="${DOCDOWN_SHARED_DIR}/smoke/run.log"
+
+          rm -rf "${smoke_output_dir}"
+          mkdir -p "${smoke_output_dir}"
+          "${DOCDOWN_CURRENT_LINK}/.venv/bin/docdown" \
+            "${DOCDOWN_SHARED_DIR}/smoke/input.pdf" \
+            -o "${smoke_output_dir}" \
+            --log-level INFO \
+            2> >(tee -a "${smoke_log}" >&2)
+
+          test -s "${smoke_output_dir}/final.md"
+          grep -q "Run Summary" "${smoke_log}"
+
+          if [ -n "${previous_release}" ] && [ -d "${previous_release}" ]; then
+            ls -1dt "${DOCDOWN_RELEASES_DIR}"/* | tail -n +6 | xargs -r rm -rf
+          fi
+
+      - name: Roll back on failure
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${PREVIOUS_RELEASE:-}" ] && [ -d "${PREVIOUS_RELEASE}" ]; then
+            sudo /usr/local/bin/docdown-activate-release "${PREVIOUS_RELEASE}"
+            sudo systemctl restart docdown-worker
+            sudo systemctl restart docdown-api
+          fi
+
+      - name: Deployment prerequisites
+        if: always()
+        run: |
+          cat <<'EOF'
+          Runner prerequisites:
+          - labels: self-hosted, linux, x64, docdown
+          - user: docdown-runner
+          - writable paths: /opt/docdown, /opt/docdown/releases, /opt/docdown/shared, /opt/docdown/workspace
+          - privileged commands:
+            * /usr/local/bin/docdown-activate-release <release-path>
+            * systemctl restart docdown-worker
+            * systemctl restart docdown-api
+
+          Secrets:
+          - No mandatory repository secret for v1 local self-hosted deployment.
+          - Optional future secrets for remote orchestration:
+            * DOCDOWN_DEPLOY_HOST
+            * DOCDOWN_DEPLOY_SSH_KEY
+          EOF

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,6 +83,7 @@ jobs:
           mkdir -p "${smoke_output_dir}"
           "${DOCDOWN_CURRENT_LINK}/.venv/bin/docdown" \
             "${DOCDOWN_SHARED_DIR}/smoke/input.pdf" \
+            --config "${DOCDOWN_CURRENT_LINK}/docdown.yaml" \
             -o "${smoke_output_dir}" \
             --log-level INFO \
             2> >(tee "${smoke_stderr_log}" >&2)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare release, activate, and verify
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   deploy:
     name: Deploy to local runner
+    timeout-minutes: 30
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,8 +59,8 @@ jobs:
           "${release_dir}/.venv/bin/pip" install "${release_dir}"
 
           sudo /usr/local/bin/docdown-activate-release "${release_dir}"
-          sudo systemctl restart docdown-worker
-          sudo systemctl restart docdown-api
+          sudo /usr/bin/systemctl restart docdown-worker
+          sudo /usr/bin/systemctl restart docdown-api
 
           smoke_output_dir="${DOCDOWN_SHARED_DIR}/smoke/output"
           smoke_log="${DOCDOWN_SHARED_DIR}/smoke/run.log"
@@ -88,8 +88,8 @@ jobs:
 
           if [ -n "${PREVIOUS_RELEASE:-}" ] && [ -d "${PREVIOUS_RELEASE}" ]; then
             sudo /usr/local/bin/docdown-activate-release "${PREVIOUS_RELEASE}"
-            sudo systemctl restart docdown-worker
-            sudo systemctl restart docdown-api
+            sudo /usr/bin/systemctl restart docdown-worker
+            sudo /usr/bin/systemctl restart docdown-api
           fi
 
       - name: Deployment prerequisites
@@ -102,8 +102,8 @@ jobs:
           - writable paths: /opt/docdown, /opt/docdown/releases, /opt/docdown/shared, /opt/docdown/workspace
           - privileged commands:
             * /usr/local/bin/docdown-activate-release <release-path>
-            * systemctl restart docdown-worker
-            * systemctl restart docdown-api
+            * /usr/bin/systemctl restart docdown-worker
+            * /usr/bin/systemctl restart docdown-api
 
           Secrets:
           - No mandatory repository secret for v1 local self-hosted deployment.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: docdown-cd-main
   cancel-in-progress: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -147,6 +147,8 @@ jobs:
           Runner prerequisites:
           - labels: self-hosted, linux, x64, docdown
           - user: docdown-runner
+          - python: python3 must resolve to >= 3.10 with venv support (python3-venv)
+          - system tools: qpdf, pandoc, ghostscript
           - writable paths: /opt/docdown, /opt/docdown/releases, /opt/docdown/shared, /opt/docdown/workspace
           - privileged commands:
             * /usr/local/bin/docdown-activate-release <release-path>

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
           sudo /usr/bin/systemctl restart docdown-api
 
           smoke_output_dir="${DOCDOWN_SHARED_DIR}/smoke/output"
-          smoke_log="${DOCDOWN_SHARED_DIR}/smoke/run.log"
+          smoke_log="${smoke_output_dir}/run.log"
 
           rm -rf "${smoke_output_dir}"
           mkdir -p "${smoke_output_dir}"
@@ -71,7 +71,7 @@ jobs:
             "${DOCDOWN_SHARED_DIR}/smoke/input.pdf" \
             -o "${smoke_output_dir}" \
             --log-level INFO \
-            2> >(tee -a "${smoke_log}" >&2)
+            2> >(tee "${smoke_log}" >&2)
 
           test -s "${smoke_output_dir}/final.md"
           grep -q "Run Summary" "${smoke_log}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOCDOWN_DEPLOY_ROOT: /opt/docdown
   DOCDOWN_RELEASES_DIR: /opt/docdown/releases
   DOCDOWN_CURRENT_LINK: /opt/docdown/current
   DOCDOWN_SHARED_DIR: /opt/docdown/shared

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,6 +56,13 @@ jobs:
           mkdir "${release_dir}"
           cp -a "${DOCDOWN_WORKSPACE_DIR}/repo/." "${release_dir}/"
 
+          if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'
+          then
+            echo "python3 must be >= 3.10 for DocDown deploy. Install Python 3.10+ on the runner host." >&2
+            python3 --version >&2 || true
+            exit 1
+          fi
+
           python3 -m venv "${release_dir}/.venv"
           "${release_dir}/.venv/bin/pip" install --upgrade pip
           "${release_dir}/.venv/bin/pip" install "${release_dir}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          release_id="$(date -u +%Y%m%d%H%M%S)-${GITHUB_SHA::7}"
+          release_id="$(date -u +%Y%m%d%H%M%S)-${GITHUB_SHA::7}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           release_dir="${DOCDOWN_RELEASES_DIR}/${release_id}"
           previous_release=""
 
@@ -51,7 +51,12 @@ jobs:
           cp -a "${GITHUB_WORKSPACE}" "${DOCDOWN_WORKSPACE_DIR}/repo"
           rm -rf "${DOCDOWN_WORKSPACE_DIR}/repo/.git"
 
-          mkdir -p "${release_dir}"
+          if [ -e "${release_dir}" ]; then
+            echo "Release directory already exists: ${release_dir}" >&2
+            exit 1
+          fi
+
+          mkdir "${release_dir}"
           cp -a "${DOCDOWN_WORKSPACE_DIR}/repo/." "${release_dir}/"
 
           python3 -m venv "${release_dir}/.venv"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Prepare release, activate, and verify
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,7 +95,7 @@ jobs:
           fi
 
           # Keep the 5 newest release directories; remove older ones safely.
-          find "${DOCDOWN_RELEASES_DIR}" \
+          if ! find "${DOCDOWN_RELEASES_DIR}" \
             -mindepth 1 \
             -maxdepth 1 \
             -type d \
@@ -116,6 +116,9 @@ jobs:
                 rm -rf -- "${release_path}"
               done
             }
+          then
+            echo "Warning: release retention cleanup failed; continuing deployment." >&2
+          fi
 
       - name: Roll back on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qpdf pandoc ghostscript
+
+      - name: Install project dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Packaging check
+        run: |
+          python -m pip install build
+          python -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,12 @@ permissions:
 
 jobs:
   validate:
-    name: Validate and test
+    name: Validate and test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout
@@ -20,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install system dependencies
         run: |

--- a/docs/notes/2026-04-13_12-30-00.md
+++ b/docs/notes/2026-04-13_12-30-00.md
@@ -1,0 +1,36 @@
+GitHub setup needed:
+1. Add self-hosted runners for this repo in Settings -> Actions -> Runners.
+2. Register runner service on node01, and optionally node02 as failover.
+3. Ensure runner labels include self-hosted, linux, x64, docdown so they match [ cd.yml ](.github/workflows/cd.yml).
+4. Keep Actions permissions enabled for the repo.
+5. Secrets are not required for the current v1 local deployment design (as documented in the workflow).
+
+Host setup needed on node01/02:
+1. Install runtime/system tools used by deployment and conversion:
+- git
+- python3 + venv support
+- qpdf
+- pandoc
+- ghostscript
+2. Create and run runner under docdown-runner account.
+3. Create and permission paths:
+- /opt/docdown
+- /opt/docdown/releases
+- /opt/docdown/current
+- /opt/docdown/shared
+- /opt/docdown/workspace
+4. Install the release activation wrapper at /usr/local/bin/docdown-activate-release.
+5. Add sudoers entries allowing only:
+- /usr/local/bin/docdown-activate-release
+- systemctl restart docdown-worker
+- systemctl restart docdown-api
+6. Install and enable systemd units:
+- docdown-worker
+- docdown-api
+7. Place smoke input file at /opt/docdown/shared/smoke/input.pdf.
+
+Important nuance for node01/node02:
+- Right now, [ cd.yml ](.github/workflows/cd.yml) can run on any runner with the same labels.
+- If you want strict primary node01 and fallback node02 behavior, we should add distinct labels (for example docdown-primary and docdown-fallback) and adjust workflow strategy accordingly.
+
+If you want, I can draft the exact node bootstrap checklist and runner registration commands next.

--- a/docs/notes/2026-04-13_12-30-00.md
+++ b/docs/notes/2026-04-13_12-30-00.md
@@ -8,7 +8,7 @@ GitHub setup needed:
 Host setup needed on node01/02:
 1. Install runtime/system tools used by deployment and conversion:
 - git
-- python3 + venv support
+- python3.10+ with venv support (for example Ubuntu 22.04+)
 - qpdf
 - pandoc
 - ghostscript

--- a/docs/notes/2026-04-13_12-30-00.md
+++ b/docs/notes/2026-04-13_12-30-00.md
@@ -22,8 +22,8 @@ Host setup needed on node01/02:
 4. Install the release activation wrapper at /usr/local/bin/docdown-activate-release.
 5. Add sudoers entries allowing only:
 - /usr/local/bin/docdown-activate-release
-- systemctl restart docdown-worker
-- systemctl restart docdown-api
+- /usr/bin/systemctl restart docdown-worker
+- /usr/bin/systemctl restart docdown-api
 6. Install and enable systemd units:
 - docdown-worker
 - docdown-api

--- a/docs/notes/2026-04-13_12-30-00.md
+++ b/docs/notes/2026-04-13_12-30-00.md
@@ -1,7 +1,7 @@
 GitHub setup needed:
 1. Add self-hosted runners for this repo in Settings -> Actions -> Runners.
 2. Register runner service on node01, and optionally node02 as failover.
-3. Ensure runner labels include self-hosted, linux, x64, docdown so they match [ cd.yml ](.github/workflows/cd.yml).
+3. Ensure runner labels include self-hosted, linux, x64, docdown so they match [cd.yml](../../.github/workflows/cd.yml).
 4. Keep Actions permissions enabled for the repo.
 5. Secrets are not required for the current v1 local deployment design (as documented in the workflow).
 
@@ -30,7 +30,7 @@ Host setup needed on node01/02:
 7. Place smoke input file at /opt/docdown/shared/smoke/input.pdf.
 
 Important nuance for node01/node02:
-- Right now, [ cd.yml ](.github/workflows/cd.yml) can run on any runner with the same labels.
+- Right now, [cd.yml](../../.github/workflows/cd.yml) can run on any runner with the same labels.
 - If you want strict primary node01 and fallback node02 behavior, we should add distinct labels (for example docdown-primary and docdown-fallback) and adjust workflow strategy accordingly.
 
 If you want, I can draft the exact node bootstrap checklist and runner registration commands next.

--- a/docs/notes/2026-04-13_12-30-00.md
+++ b/docs/notes/2026-04-13_12-30-00.md
@@ -13,12 +13,12 @@ Host setup needed on node01/02:
 - pandoc
 - ghostscript
 2. Create and run runner under docdown-runner account.
-3. Create and permission paths:
+3. Create and permission base paths:
 - /opt/docdown
 - /opt/docdown/releases
-- /opt/docdown/current
 - /opt/docdown/shared
 - /opt/docdown/workspace
+	- Do not pre-create /opt/docdown/current as a directory; it is an active symlink managed by /usr/local/bin/docdown-activate-release.
 4. Install the release activation wrapper at /usr/local/bin/docdown-activate-release.
 5. Add sudoers entries allowing only:
 - /usr/local/bin/docdown-activate-release

--- a/docs/notes/2026-04-13_12-30-00.md
+++ b/docs/notes/2026-04-13_12-30-00.md
@@ -18,7 +18,7 @@ Host setup needed on node01/02:
 - /opt/docdown/releases
 - /opt/docdown/shared
 - /opt/docdown/workspace
-	- Do not pre-create /opt/docdown/current as a directory; it is an active symlink managed by /usr/local/bin/docdown-activate-release.
+  - Do not pre-create /opt/docdown/current as a directory; it is an active symlink managed by /usr/local/bin/docdown-activate-release.
 4. Install the release activation wrapper at /usr/local/bin/docdown-activate-release.
 5. Add sudoers entries allowing only:
 - /usr/local/bin/docdown-activate-release

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -16,7 +16,7 @@ sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/workspace
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y git python3 python3-venv qpdf pandoc ghostscript
+sudo apt-get install -y ca-certificates curl git python3 python3-venv qpdf pandoc ghostscript
 ```
 
 3. Clean any previous broken runner installation.

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -5,7 +5,8 @@ Everything below is intended to be run from the `clusteradmin` shell.
 1. Create service account and required directories.
 
 ```bash
-sudo useradd --create-home --shell /bin/bash docdown-runner
+sudo groupadd --force docdown-runner
+sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/releases
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/shared

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -16,7 +16,7 @@ sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/workspace
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl git python3 python3-venv qpdf pandoc ghostscript
+sudo apt-get install -y ca-certificates curl git python3.10 python3.10-venv qpdf pandoc ghostscript
 ```
 
 3. Clean any previous broken runner installation.

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -6,7 +6,9 @@ Everything below is intended to be run from the `clusteradmin` shell.
 
 ```bash
 sudo groupadd --force docdown-runner
-sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner
+if ! id -u docdown-runner >/dev/null 2>&1; then
+  sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner
+fi
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/releases
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/shared

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -35,7 +35,6 @@ sudo -u docdown-runner -H mkdir -p /home/docdown-runner/actions-runner
 4. Download and extract runner as `docdown-runner`.
 
 ```bash
-cd /tmp
 sudo -u docdown-runner -H bash -lc 'cd /home/docdown-runner/actions-runner && curl -fL -o actions-runner-linux-x64-2.333.1.tar.gz https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-x64-2.333.1.tar.gz && echo "18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74  actions-runner-linux-x64-2.333.1.tar.gz" | sha256sum -c && tar xzf ./actions-runner-linux-x64-2.333.1.tar.gz'
 ```
 

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -16,7 +16,12 @@ sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/workspace
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl git python3.10 python3.10-venv qpdf pandoc ghostscript
+sudo apt-get install -y ca-certificates curl git python3 python3-venv qpdf pandoc ghostscript
+python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' || {
+  echo "python3 must be >= 3.10" >&2
+  python3 --version >&2
+  exit 1
+}
 ```
 
 3. Clean any previous broken runner installation.

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -63,9 +63,9 @@ Expected in GitHub UI:
 8. Optional: remove a wrong/old runner install from current directory.
 
 ```bash
-sudo ./svc.sh stop || true
-sudo ./svc.sh uninstall || true
-./config.sh remove --token PASTE_FRESH_REPO_TOKEN_HERE
+sudo /home/docdown-runner/actions-runner/svc.sh stop || true
+sudo /home/docdown-runner/actions-runner/svc.sh uninstall || true
+sudo -u docdown-runner -H /home/docdown-runner/actions-runner/config.sh remove --token PASTE_FRESH_REPO_TOKEN_HERE
 ```
 
 9. Remaining deployment prerequisites.

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -39,7 +39,7 @@ sudo -u docdown-runner -H bash -lc 'cd /home/docdown-runner/actions-runner && cu
 
 ```bash
 RUNNER_TOKEN=PASTE_FRESH_REPO_TOKEN_HERE
-sudo -u docdown-runner -H bash -lc "cd ~/actions-runner && ./config.sh --url https://github.com/Frank-Yong/DocDown --token $RUNNER_TOKEN --name docdown-node02 --labels docdown,docdown-fallback --unattended"
+sudo -u docdown-runner -H bash -lc "cd ~/actions-runner && ./config.sh --url https://github.com/Frank-Yong/DocDown --token \"$RUNNER_TOKEN\" --name docdown-node02 --labels docdown,docdown-fallback --unattended"
 unset RUNNER_TOKEN
 ```
 

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -22,7 +22,6 @@ sudo apt-get install -y ca-certificates curl git python3 python3-venv qpdf pando
 3. Clean any previous broken runner installation.
 
 ```bash
-rm -rf ~/actions-runner
 sudo rm -rf /home/docdown-runner/actions-runner
 sudo -u docdown-runner -H mkdir -p /home/docdown-runner/actions-runner
 ```

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -1,0 +1,81 @@
+# Runner Up-And-Running TODO (Run As clusteradmin)
+
+Everything below is intended to be run from the `clusteradmin` shell.
+
+1. Create service account and required directories.
+
+```bash
+sudo useradd --create-home --shell /bin/bash docdown-runner
+sudo install -d -o docdown-runner -g docdown-runner /opt/docdown
+sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/releases
+sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/shared
+sudo install -d -o docdown-runner -g docdown-runner /opt/docdown/workspace
+```
+
+2. Install host dependencies.
+
+```bash
+sudo apt-get update
+sudo apt-get install -y git python3 python3-venv qpdf pandoc ghostscript
+```
+
+3. Clean any previous broken runner installation.
+
+```bash
+rm -rf ~/actions-runner
+sudo rm -rf /home/docdown-runner/actions-runner
+sudo -u docdown-runner -H mkdir -p /home/docdown-runner/actions-runner
+```
+
+4. Download and extract runner as `docdown-runner`.
+
+```bash
+cd /tmp
+sudo -u docdown-runner -H mkdir -p /home/docdown-runner/actions-runner
+sudo -u docdown-runner -H bash -lc 'cd /home/docdown-runner/actions-runner && curl -fL -o actions-runner-linux-x64-2.333.1.tar.gz https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-x64-2.333.1.tar.gz && echo "18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74  actions-runner-linux-x64-2.333.1.tar.gz" | sha256sum -c && tar xzf ./actions-runner-linux-x64-2.333.1.tar.gz'
+```
+
+5. Register runner (fresh token from repo Settings -> Actions -> Runners).
+
+```bash
+RUNNER_TOKEN=PASTE_FRESH_REPO_TOKEN_HERE
+sudo -u docdown-runner -H bash -lc "cd ~/actions-runner && ./config.sh --url https://github.com/Frank-Yong/DocDown --token $RUNNER_TOKEN --name docdown-node02 --labels docdown,docdown-fallback --unattended"
+unset RUNNER_TOKEN
+```
+
+6. Install and start runner service.
+
+```bash
+sudo bash -lc 'cd /home/docdown-runner/actions-runner && ./svc.sh install docdown-runner && ./svc.sh start && ./svc.sh status'
+```
+
+7. Validate files and registration.
+
+```bash
+sudo -u docdown-runner -H bash -lc 'ls -la ~/actions-runner'
+sudo -u docdown-runner -H bash -lc 'find ~ -maxdepth 3 -type f -name svc.sh'
+```
+
+Expected in GitHub UI:
+
+- Runner name: `docdown-node02`
+- Labels: `self-hosted`, `linux`, `x64`, `docdown`, `docdown-fallback`
+
+8. Optional: remove a wrong/old runner install from current directory.
+
+```bash
+sudo ./svc.sh stop || true
+sudo ./svc.sh uninstall || true
+./config.sh remove --token PASTE_FRESH_REPO_TOKEN_HERE
+```
+
+9. Remaining deployment prerequisites.
+
+- Install release activation wrapper: `/usr/local/bin/docdown-activate-release`
+- Add scoped sudoers for `docdown-runner`:
+  - `/usr/local/bin/docdown-activate-release`
+  - `/usr/bin/systemctl restart docdown-worker`
+  - `/usr/bin/systemctl restart docdown-api`
+- Install/enable `docdown-worker` and `docdown-api` systemd units
+- Place smoke input file at `/opt/docdown/shared/smoke/input.pdf`
+- Run one test deploy from `main` and confirm CD job passes

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -37,7 +37,7 @@ sudo -u docdown-runner -H bash -lc 'cd /home/docdown-runner/actions-runner && cu
 5. Register runner (fresh token from repo Settings -> Actions -> Runners).
 
 ```bash
-RUNNER_TOKEN=PASTE_FRESH_REPO_TOKEN_HERE
+read -rsp "Runner token: " RUNNER_TOKEN; echo
 sudo -u docdown-runner -H bash -lc "cd ~/actions-runner && ./config.sh --url https://github.com/Frank-Yong/DocDown --token \"$RUNNER_TOKEN\" --name docdown-node02 --labels docdown,docdown-fallback --unattended"
 unset RUNNER_TOKEN
 ```

--- a/docs/notes/2026-04-13_12-45-00.md
+++ b/docs/notes/2026-04-13_12-45-00.md
@@ -35,7 +35,6 @@ sudo -u docdown-runner -H mkdir -p /home/docdown-runner/actions-runner
 
 ```bash
 cd /tmp
-sudo -u docdown-runner -H mkdir -p /home/docdown-runner/actions-runner
 sudo -u docdown-runner -H bash -lc 'cd /home/docdown-runner/actions-runner && curl -fL -o actions-runner-linux-x64-2.333.1.tar.gz https://github.com/actions/runner/releases/download/v2.333.1/actions-runner-linux-x64-2.333.1.tar.gz && echo "18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74  actions-runner-linux-x64-2.333.1.tar.gz" | sha256sum -c && tar xzf ./actions-runner-linux-x64-2.333.1.tar.gz'
 ```
 


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow at .github/workflows/ci.yml
- run CI on pull requests to main using ubuntu-latest
- install baseline system dependencies in CI: qpdf, pandoc, ghostscript
- install project dependencies and run tests with pytest -q
- add packaging check with python -m build
- add GitHub Actions CD workflow at .github/workflows/cd.yml
- trigger CD on push to main and run on labeled self-hosted runner: self-hosted, linux, x64, docdown
- implement first-pass deploy flow using release directories and /opt/docdown/current symlink activation via /usr/local/bin/docdown-activate-release
- restart docdown-worker and docdown-api after activation
- run smoke conversion check and verify output plus run summary logging
- implement rollback step on failure to previous release target

## Acceptance Criteria Mapping (Task 10.1)
- CI workflow exists under .github/workflows/ci.yml: done
- CI runs on pull requests: done
- CI uses GitHub-hosted Ubuntu runner and required dependencies: done
- CD workflow exists under .github/workflows/cd.yml: done
- CD triggers on push to main: done
- CD runs on local hosted runner labels: done
- CD deploy path is documented and repeatable in workflow commands: done
- rollback path is implemented in workflow: done
- runner prerequisites and secret expectations are documented in workflow output: done

## Validation
- local CI-equivalent run completed successfully:
  - python -m pip install --upgrade pip
  - python -m pip install -e ".[dev]"
  - pytest -q (178 passed, 1 skipped)
  - python -m pip install build
  - python -m build
- PR CI check is green: Validate and test

## Reviewer Checklist
- verify CI workflow scope and runner image in .github/workflows/ci.yml
- verify CD runner labels match Task 10.0 contract in .github/workflows/cd.yml
- verify deploy, smoke, and rollback command paths are acceptable for node01/node02 setup
- confirm smoke input file location expectation at /opt/docdown/shared/smoke/input.pdf
- confirm sudo wrapper and systemctl permissions are consistent with runner provisioning

## Risks / Notes
- CD assumes Task 10.0 runner prerequisites are already provisioned
- apt-based install is validated in GitHub-hosted Linux runtime, not on local Windows shell
- first release rollback requires an existing previous release target

## Rollout / Rollback
- rollout: merge to main triggers CD on self-hosted runner
- rollback: on deploy or smoke failure, workflow re-points active release to previous target and restarts services