### PR TITLE
CD: bootstrap smoke input when host file is missing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,10 +101,15 @@ jobs:
           rm -rf "${smoke_output_dir}"
           mkdir -p "${smoke_output_dir}" "${smoke_input_dir}"
 
-          if [ ! -s "${smoke_input_pdf}" ]; then
-            if [ -s "${release_sample_pdf}" ]; then
+          if [ -e "${smoke_input_pdf}" ] && [ ! -f "${smoke_input_pdf}" ]; then
+            echo "Smoke input path exists but is not a regular file: ${smoke_input_pdf}" >&2
+            exit 1
+          fi
+
+          if [ ! -f "${smoke_input_pdf}" ] || [ ! -s "${smoke_input_pdf}" ]; then
+            if [ -f "${release_sample_pdf}" ] && [ -s "${release_sample_pdf}" ]; then
               cp -f "${release_sample_pdf}" "${smoke_input_pdf}"
-            elif [ -s "${release_sample_pdf_rich}" ]; then
+            elif [ -f "${release_sample_pdf_rich}" ] && [ -s "${release_sample_pdf_rich}" ]; then
               cp -f "${release_sample_pdf_rich}" "${smoke_input_pdf}"
             else
               echo "Smoke input missing at ${smoke_input_pdf} and no sample PDF found in release." >&2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,11 +93,27 @@ jobs:
           smoke_output_dir="${DOCDOWN_SHARED_DIR}/smoke/output"
           smoke_log="${smoke_output_dir}/run.log"
           smoke_stderr_log="${smoke_output_dir}/stderr.log"
+          smoke_input_dir="${DOCDOWN_SHARED_DIR}/smoke"
+          smoke_input_pdf="${smoke_input_dir}/input.pdf"
+          release_sample_pdf="${DOCDOWN_CURRENT_LINK}/sample-input.pdf"
+          release_sample_pdf_rich="${DOCDOWN_CURRENT_LINK}/sample-input-rich.pdf"
 
           rm -rf "${smoke_output_dir}"
-          mkdir -p "${smoke_output_dir}"
+          mkdir -p "${smoke_output_dir}" "${smoke_input_dir}"
+
+          if [ ! -s "${smoke_input_pdf}" ]; then
+            if [ -s "${release_sample_pdf}" ]; then
+              cp -f "${release_sample_pdf}" "${smoke_input_pdf}"
+            elif [ -s "${release_sample_pdf_rich}" ]; then
+              cp -f "${release_sample_pdf_rich}" "${smoke_input_pdf}"
+            else
+              echo "Smoke input missing at ${smoke_input_pdf} and no sample PDF found in release." >&2
+              exit 1
+            fi
+          fi
+
           "${DOCDOWN_CURRENT_LINK}/.venv/bin/docdown" \
-            "${DOCDOWN_SHARED_DIR}/smoke/input.pdf" \
+            "${smoke_input_pdf}" \
             --config "${DOCDOWN_CURRENT_LINK}/docdown.yaml" \
             -o "${smoke_output_dir}" \
             --log-level INFO \


### PR DESCRIPTION
## Summary
- updates CD workflow smoke verification to avoid hard dependency on a pre-seeded host file
- if /opt/docdown/shared/smoke/input.pdf is missing or empty, CD now copies a bundled sample PDF from the activated release
- keeps existing behavior when a valid host smoke input already exists
- fails with a clear error only when neither shared input nor bundled sample PDFs are available

## Validation
- workflow file diagnostics report no YAML errors
- smoke input source paths were verified in repository content and wired into deploy step

## Risk and Rollback
- low risk, scoped to smoke-test input preparation only
- no deploy/install path changes
- rollback remains unchanged and can still reactivate previous release as before