### PR TITLE
CD: fail fast when required host tools are missing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,6 +67,18 @@ jobs:
             exit 1
           fi
 
+          missing_tools=""
+          for tool in qpdf pandoc gs; do
+            if ! command -v "${tool}" >/dev/null 2>&1; then
+              missing_tools="${missing_tools} ${tool}"
+            fi
+          done
+          if [ -n "${missing_tools}" ]; then
+            echo "Missing required system tools:${missing_tools}" >&2
+            echo "Install qpdf, pandoc, and ghostscript on the runner host before running CD." >&2
+            exit 1
+          fi
+
           python3 -m venv "${release_dir}/.venv"
           "${release_dir}/.venv/bin/pip" install --upgrade pip
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,22 +69,24 @@ jobs:
 
           required_tools=(qpdf pandoc gs)
           missing_tools=()
-          install_hints=()
           for tool in "${required_tools[@]}"; do
-            case "${tool}" in
-              gs)
-                install_hints+=("ghostscript (gs)")
-                ;;
-              *)
-                install_hints+=("${tool}")
-                ;;
-            esac
-
             if ! command -v "${tool}" >/dev/null 2>&1; then
               missing_tools+=("${tool}")
             fi
           done
           if [ "${#missing_tools[@]}" -gt 0 ]; then
+            install_hints=()
+            for tool in "${missing_tools[@]}"; do
+              case "${tool}" in
+                gs)
+                  install_hints+=("ghostscript (gs)")
+                  ;;
+                *)
+                  install_hints+=("${tool}")
+                  ;;
+              esac
+            done
+
             echo "Missing required system tools: ${missing_tools[*]}" >&2
             echo "Install packages on the runner host: ${install_hints[*]}." >&2
             exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,15 +67,16 @@ jobs:
             exit 1
           fi
 
+          required_tools=(qpdf pandoc gs)
           missing_tools=""
-          for tool in qpdf pandoc gs; do
+          for tool in "${required_tools[@]}"; do
             if ! command -v "${tool}" >/dev/null 2>&1; then
               missing_tools="${missing_tools} ${tool}"
             fi
           done
           if [ -n "${missing_tools}" ]; then
             echo "Missing required system tools:${missing_tools}" >&2
-            echo "Install qpdf, pandoc, and ghostscript on the runner host before running CD." >&2
+            echo "Install packages on the runner host: qpdf pandoc ghostscript (provides gs)." >&2
             exit 1
           fi
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,15 +68,25 @@ jobs:
           fi
 
           required_tools=(qpdf pandoc gs)
-          missing_tools=""
+          missing_tools=()
+          install_hints=()
           for tool in "${required_tools[@]}"; do
+            case "${tool}" in
+              gs)
+                install_hints+=("ghostscript (gs)")
+                ;;
+              *)
+                install_hints+=("${tool}")
+                ;;
+            esac
+
             if ! command -v "${tool}" >/dev/null 2>&1; then
-              missing_tools="${missing_tools} ${tool}"
+              missing_tools+=("${tool}")
             fi
           done
-          if [ -n "${missing_tools}" ]; then
-            echo "Missing required system tools:${missing_tools}" >&2
-            echo "Install packages on the runner host: qpdf pandoc ghostscript (provides gs)." >&2
+          if [ "${#missing_tools[@]}" -gt 0 ]; then
+            echo "Missing required system tools: ${missing_tools[*]}" >&2
+            echo "Install packages on the runner host: ${install_hints[*]}." >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- adds an early prerequisite check in CD for required host binaries: qpdf, pandoc, and gs
- exits with a clear error message before venv/package install when tools are missing
- keeps existing deploy behavior unchanged when prerequisites are present

## Validation
- workflow diagnostics report no YAML errors for .github/workflows/cd.yml
- change tested structurally by inspecting generated diff and shell logic

## Risks
- low risk; scoped to preflight validation in deploy script
- no packaging, activation, rollback, or smoke command changes

## Rollout
- merge and rerun CD on main
- with tools now installed on runner host, deploy should proceed past previous qpdf failure point