### PR TITLE
CI/CD: update pinned actions for Node 24 runtime

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Prepare release, activate, and verify
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- updates pinned action SHAs only:
  - actions/checkout from v4 SHA to v5 SHA in CI and CD
  - actions/setup-python from v5 SHA to v6 SHA in CI
- no workflow logic changes; this PR is limited to action version pin updates

## Validation
- workflow diagnostics report no errors for .github/workflows/ci.yml and .github/workflows/cd.yml
- SHAs were resolved from upstream action tags before updating pins

## Risks
- low risk; action pin updates only

## Rollout
- merge PR
- verify subsequent CI/CD runs complete without the Node.js 20 deprecation warning from checkout