### PR TITLE
docs: finalize Task 10.2 conversion workflow rollout notes

### DIFF
--- a/DocDown.code-workspace
+++ b/DocDown.code-workspace
@@ -4,6 +4,9 @@
 			"path": "."
 		},
 		{
+			"path": "../DocDownOps"
+		},
+		{
 			"path": "../Equinor"
 		}
 	]

--- a/DocDown.code-workspace
+++ b/DocDown.code-workspace
@@ -1,16 +1,10 @@
 {
-    "folders": [
-        {
-            "path": "."
-        },
-        {
-            "path": "../DocDownOps"
-        },
-        {
-            "path": "../Equinor"
-        }
-    ],
-    "settings": {
-        "powershell.cwd": "DocDownOps"
-    }
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../Equinor"
+		}
+	]
 }

--- a/DocDown.code-workspace
+++ b/DocDown.code-workspace
@@ -9,5 +9,8 @@
         {
             "path": "../Equinor"
         }
-    ]
+    ],
+    "settings": {
+        "powershell.cwd": "DocDownOps"
+    }
 }

--- a/DocDown.code-workspace
+++ b/DocDown.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../DocDownOps"
+		},
+		{
+			"path": "../Equinor"
+		}
+	],
+	"settings": {
+		"powershell.cwd": "DocDown"
+	}
+}

--- a/docs/notes/2026-04-14_06-35-00.md
+++ b/docs/notes/2026-04-14_06-35-00.md
@@ -74,11 +74,11 @@ If you want, next I can draft a concrete 10.2 execution plan in task-10.2-conver
 
 ***
 
-You are absolutely right. A LAN-only local runner cannot be the only entrypoint if the feature must work from anywhere with GitHub access.
+You are absolutely right. A LAN-only DocDownOps polling runner service cannot be the only entrypoint if the feature must work from anywhere with GitHub access.
 
 Recommended model
 
-1. Keep conversion execution on your local/self-hosted runner.
+1. Keep conversion execution on your local DocDownOps polling runner service.
 2. Move submission and orchestration to GitHub-facing workflows.
 3. Use an operations repo as the control plane (good idea).
 
@@ -86,7 +86,7 @@ How this solves your constraint
 
 1. Users anywhere can submit jobs through GitHub (API, workflow_dispatch, or PR comment command).
 2. The ops repo queues jobs.
-3. Your local runner (inside LAN) pulls jobs from GitHub and processes them.
+3. Your local DocDownOps polling runner service (inside LAN) pulls jobs from GitHub and processes them.
 4. Results are pushed back to GitHub (artifact, commit/PR, or comment with link), so submitter can access markdown remotely.
 
 Important source caveat

--- a/docs/notes/2026-04-14_06-35-00.md
+++ b/docs/notes/2026-04-14_06-35-00.md
@@ -1,0 +1,104 @@
+Yes, this is exactly the right thing to define first for 10.2.
+
+Recommended approach for v1
+
+1. Treat every request as a submission job with one normalized input contract.
+2. Support two source adapters:
+- Local file source: submitter uploads or points to a local path on the host.
+- Git source: submitter provides repo, ref, and file path.
+3. Convert through one common pipeline after intake:
+- Resolve source to a single staged PDF path.
+- Run DocDown conversion.
+- Store final markdown and metadata.
+- Return a stable result reference to the submitter.
+
+Concrete flow
+
+1. Submit
+- API or CLI creates a job record with:
+- source type: local or git
+- source locator
+- submitter identity
+- optional callback target
+
+2. Ingest
+- Local adapter copies file into isolated job workspace.
+- Git adapter shallow-fetches only required ref and file, then copies the target PDF into job workspace.
+- Validate extension, size, and basic PDF readability before conversion.
+
+3. Convert
+- Run DocDown in job workspace.
+- Produce final markdown plus logs and status.
+
+4. Publish result for submitter
+- Store markdown in a result store keyed by job id.
+- Return a retrieval URL or API endpoint.
+- Keep source and output traceability in job metadata.
+
+How submitter gets the markdown
+
+Best default:
+- Result endpoint: submitter polls job status, then downloads markdown from a job result URL.
+
+Optional extras:
+- Push back to a repo path in a target branch.
+- Create PR automatically with generated markdown.
+- Post status and link to PR comment.
+
+For your specific source types
+
+- Local file case:
+Use direct upload or local path ingestion into job workspace.
+
+- File in another repo:
+Use a read-only token or GitHub App installation with repo allowlist.
+Require repo, ref, and path; fetch only what is needed.
+
+Key guardrails
+
+1. Security
+- Allowlist repos for git source.
+- No broad token scopes.
+- Per-job isolated work directory.
+
+2. Reliability
+- Idempotency key so retries do not duplicate work.
+- Clear failure states: ingest failed, validation failed, conversion failed.
+
+3. UX
+- Job id immediately returned.
+- Simple status model: queued, running, succeeded, failed.
+- Always provide logs pointer on failure.
+
+If you want, next I can draft a concrete 10.2 execution plan in task-10.2-conversion-workflow.md with API shapes, job schema, and v1 acceptance criteria.
+
+***
+
+You are absolutely right. A LAN-only local runner cannot be the only entrypoint if the feature must work from anywhere with GitHub access.
+
+Recommended model
+
+1. Keep conversion execution on your local/self-hosted runner.
+2. Move submission and orchestration to GitHub-facing workflows.
+3. Use an operations repo as the control plane (good idea).
+
+How this solves your constraint
+
+1. Users anywhere can submit jobs through GitHub (API, workflow_dispatch, or PR comment command).
+2. The ops repo queues jobs.
+3. Your local runner (inside LAN) pulls jobs from GitHub and processes them.
+4. Results are pushed back to GitHub (artifact, commit/PR, or comment with link), so submitter can access markdown remotely.
+
+Important source caveat
+
+1. If source PDF is in a GitHub repo: easy, fully remote-compatible.
+2. If source PDF is only on a local machine: it must first be uploaded to GitHub-accessible storage (repo commit, release asset, or dedicated intake repo).  
+   GitHub alone cannot read a random file from someone’s laptop without an upload step.
+
+Practical v1 contract
+
+1. Supported input: repo/ref/path (PDF in GitHub).
+2. Optional local-file path support later via CLI helper that uploads file to an intake repo, then submits job.
+3. Output: markdown committed to target repo branch or uploaded artifact + status comment.
+
+I think an ops repo is the cleanest path for 10.2. If you want, I can draft the exact 10.2 architecture and job lifecycle (submit, queue, claim, process, publish) in your plan file next.

--- a/docs/notes/2026-04-14_07-10-00.md
+++ b/docs/notes/2026-04-14_07-10-00.md
@@ -1,0 +1,156 @@
+# Conversion Worker Runbook (Task 10.2)
+
+## Purpose
+
+Operational guide for running the DocDown conversion worker when GitHub is the control plane and the local LAN runner is the execution plane.
+
+This runbook covers:
+
+- start/stop/restart
+- health and queue checks
+- stuck-job diagnosis and recovery
+- replay procedure by `job_id`
+
+## Scope And Assumptions
+
+- Worker runs on local self-hosted host.
+- Job manifests are stored in an operations repository.
+- Job state directories exist in ops repo:
+  - `jobs/queued/`
+  - `jobs/running/`
+  - `jobs/done/`
+  - `status/`
+- Worker service name in examples: `docdown-conversion-worker`.
+
+## Service Control
+
+```bash
+# status
+sudo systemctl status docdown-conversion-worker --no-pager
+
+# start
+sudo systemctl start docdown-conversion-worker
+
+# stop
+sudo systemctl stop docdown-conversion-worker
+
+# restart
+sudo systemctl restart docdown-conversion-worker
+
+# follow logs
+sudo journalctl -u docdown-conversion-worker -f
+```
+
+## Health Checks
+
+### Runner Host
+
+```bash
+python3 --version
+qpdf --version
+pandoc --version
+gs --version
+df -h /opt/docdown
+```
+
+Expected:
+
+- Python meets minimum supported version.
+- Required tools resolve (`qpdf`, `pandoc`, `gs`).
+- Disk has enough free space for largest expected PDF and artifacts.
+
+### Queue Surface
+
+Check queue depth and stale running jobs from ops repo state.
+
+```bash
+# Example only; adapt paths/commands to implementation
+find jobs/queued -type f | wc -l
+find jobs/running -type f -mmin +30
+```
+
+Alert thresholds (initial defaults):
+
+- queued jobs > 20 for more than 10 minutes
+- any running job older than 30 minutes
+
+## Normal Operating Flow
+
+```mermaid
+flowchart TD
+    A[Job in jobs/queued] --> B[Worker claims job]
+    B --> C[Move to jobs/running]
+    C --> D[DocDown conversion]
+    D --> E{Result}
+    E -->|Success| F[Write output and summary]
+    E -->|Fail| G[Classify error]
+    F --> H[Move to jobs/done and status succeeded]
+    G --> I{Transient?}
+    I -->|Yes| J[status retrying then requeue]
+    I -->|No| K[status failed]
+```
+
+## Stuck Job Recovery
+
+A job is considered stuck if it remains in `running` past timeout and no worker activity/log updates are observed.
+
+### Step 1: Confirm Worker State
+
+```bash
+sudo systemctl status docdown-conversion-worker --no-pager
+sudo journalctl -u docdown-conversion-worker --since "30 minutes ago"
+```
+
+### Step 2: Inspect Running Job Artifact Paths
+
+- Verify workspace exists: `/opt/docdown/workspace/jobs/<job_id>`
+- Check for active file changes in logs/output.
+
+### Step 3: Classify
+
+- transient candidate: network timeout, temporary git fetch failure, lock contention
+- deterministic failure: invalid PDF, unsupported source path, policy violation
+
+### Step 4: Recover
+
+- If transient and attempts < max:
+  - mark `status/<job_id>.json` as `retrying`
+  - move manifest back to `jobs/queued/`
+- If deterministic or attempts exhausted:
+  - mark status `failed`
+  - preserve logs and summary for submitter
+
+### Step 5: Service Restart (if needed)
+
+```bash
+sudo systemctl restart docdown-conversion-worker
+sudo systemctl status docdown-conversion-worker --no-pager
+```
+
+## Replay By Job ID
+
+Use replay only after fixing root cause.
+
+1. Locate job manifest and final status for `job_id`.
+2. Copy failed manifest into a new queued job with:
+   - new `job_id`
+   - `replay_of` field pointing to original `job_id`
+   - incremented attempt metadata reset for new job lifecycle
+3. Keep original artifacts immutable for traceability.
+
+## Incident Notes Template
+
+For each incident, capture:
+
+- `job_id`
+- source locator (`repo/ref/path` or upload artifact ref)
+- failure class (transient or deterministic)
+- remediation action taken
+- replayed (yes/no) and new `job_id` if replayed
+- submitter-visible result link
+
+## CD Handoff Note
+
+CD is responsible for deploying worker code and restarting `docdown-conversion-worker`.
+
+Runtime orchestration behavior (queue claim, retry policy, artifact persistence) is controlled by Task 10.2 implementation and this runbook.

--- a/docs/notes/2026-04-14_07-10-00.md
+++ b/docs/notes/2026-04-14_07-10-00.md
@@ -69,9 +69,14 @@ find jobs/queued -type f | wc -l
 find jobs/running -type f -mmin +30
 ```
 
-Alert thresholds (initial defaults):
+Alert thresholds (initial defaults from runner env knobs):
 
-- queued jobs > 20 for more than 10 minutes
+- queued jobs > 10
+- oldest queued job age > 15 minutes
+- repeated sync failures >= 3
+
+Operational watch threshold:
+
 - any running job older than 30 minutes
 
 ## Normal Operating Flow

--- a/docs/notes/2026-04-14_07-10-00.md
+++ b/docs/notes/2026-04-14_07-10-00.md
@@ -137,11 +137,12 @@ sudo systemctl status docdownops-runner.service --no-pager
 Use replay only after fixing root cause.
 
 1. Locate job manifest and final status for `job_id`.
-2. Copy failed manifest into a new queued job with:
-   - new `job_id`
-   - `replay_of` field pointing to original `job_id`
-   - incremented attempt metadata reset for new job lifecycle
-3. Keep original artifacts immutable for traceability.
+2. Verify replay preconditions:
+  - `status/<job_id>.json` shows `failed` unless intentionally using force override
+  - `jobs/done/<job_id>.json` exists
+  - no same-id manifest is present under `jobs/queued/` or `jobs/running/`
+3. Re-queue the same `job_id` with the DocDownOps replay helper (`scripts/replay-job.sh <job_id>`), which moves the done manifest back to `jobs/queued/` and preserves the original job lineage.
+4. Keep original artifacts immutable for traceability.
 
 ## Incident Notes Template
 
@@ -151,7 +152,7 @@ For each incident, capture:
 - source locator (`repo/ref/path` or upload artifact ref)
 - failure class (transient or deterministic)
 - remediation action taken
-- replayed (yes/no) and new `job_id` if replayed
+- replayed (yes/no) and whether replay used the same `job_id`
 - submitter-visible result link
 
 ## CD Handoff Note

--- a/docs/notes/2026-04-14_07-10-00.md
+++ b/docs/notes/2026-04-14_07-10-00.md
@@ -20,25 +20,25 @@ This runbook covers:
   - `jobs/running/`
   - `jobs/done/`
   - `status/`
-- Worker service name in examples: `docdown-conversion-worker`.
+- Worker service name in examples: `docdownops-runner.service`.
 
 ## Service Control
 
 ```bash
 # status
-sudo systemctl status docdown-conversion-worker --no-pager
+sudo systemctl status docdownops-runner.service --no-pager
 
 # start
-sudo systemctl start docdown-conversion-worker
+sudo systemctl start docdownops-runner.service
 
 # stop
-sudo systemctl stop docdown-conversion-worker
+sudo systemctl stop docdownops-runner.service
 
 # restart
-sudo systemctl restart docdown-conversion-worker
+sudo systemctl restart docdownops-runner.service
 
 # follow logs
-sudo journalctl -u docdown-conversion-worker -f
+sudo journalctl -u docdownops-runner.service -f
 ```
 
 ## Health Checks
@@ -97,8 +97,8 @@ A job is considered stuck if it remains in `running` past timeout and no worker 
 ### Step 1: Confirm Worker State
 
 ```bash
-sudo systemctl status docdown-conversion-worker --no-pager
-sudo journalctl -u docdown-conversion-worker --since "30 minutes ago"
+sudo systemctl status docdownops-runner.service --no-pager
+sudo journalctl -u docdownops-runner.service --since "30 minutes ago"
 ```
 
 ### Step 2: Inspect Running Job Artifact Paths
@@ -123,8 +123,8 @@ sudo journalctl -u docdown-conversion-worker --since "30 minutes ago"
 ### Step 5: Service Restart (if needed)
 
 ```bash
-sudo systemctl restart docdown-conversion-worker
-sudo systemctl status docdown-conversion-worker --no-pager
+sudo systemctl restart docdownops-runner.service
+sudo systemctl status docdownops-runner.service --no-pager
 ```
 
 ## Replay By Job ID
@@ -151,6 +151,6 @@ For each incident, capture:
 
 ## CD Handoff Note
 
-CD is responsible for deploying worker code and restarting `docdown-conversion-worker`.
+CD is responsible for deploying worker code and restarting `docdownops-runner.service`.
 
 Runtime orchestration behavior (queue claim, retry policy, artifact persistence) is controlled by Task 10.2 implementation and this runbook.

--- a/docs/notes/2026-04-14_07-10-00.md
+++ b/docs/notes/2026-04-14_07-10-00.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Operational guide for running the DocDown conversion worker when GitHub is the control plane and the local LAN runner is the execution plane.
+Operational guide for running the DocDown conversion worker when GitHub is the control plane and the DocDownOps local polling runner service is the execution plane.
 
 This runbook covers:
 
@@ -13,7 +13,7 @@ This runbook covers:
 
 ## Scope And Assumptions
 
-- Worker runs on local self-hosted host.
+- Worker runs on a local host under the DocDownOps polling runner service model.
 - Job manifests are stored in an operations repository.
 - Job state directories exist in ops repo:
   - `jobs/queued/`

--- a/docs/notes/2026-04-14_14-40-00-node01-primary-runner-setup.md
+++ b/docs/notes/2026-04-14_14-40-00-node01-primary-runner-setup.md
@@ -2,6 +2,12 @@
 
 Purpose: set up `node01` as the active DocDown CD runner, while keeping `node02` as standby fallback.
 
+Verification status (2026-04-14):
+
+- Node01 runner registration is healthy (`docdown-node01` shows `Idle`).
+- CD smoke test is green on node01.
+- Node02 is intended to remain disabled as standby unless failover is needed.
+
 Run these commands on `node01` as `clusteradmin`.
 
 ## 1) Create service account and directories
@@ -194,6 +200,11 @@ sudo systemctl enable actions.runner.Frank-Yong-DocDown.docdown-node02.service
 sudo bash -lc 'cd /home/docdown-runner/actions-runner && ./svc.sh start'
 sudo bash -lc 'cd /home/docdown-runner/actions-runner && ./svc.sh status'
 ```
+
+Current operating posture (2026-04-14):
+
+- Keep node02 runner service disabled by default.
+- Enable node02 only for failover or maintenance windows on node01.
 
 ## 10) Smoke test CD
 

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -17,7 +17,7 @@ cat >/tmp/docdownops-host-prereq.sh <<'EOF'
 set -euo pipefail
 
 sudo apt-get update
-sudo apt-get install -y git python3
+sudo apt-get install -y git python3 qpdf pandoc ghostscript
 
 sudo groupadd --force docdown-runner
 id -u docdown-runner >/dev/null 2>&1 || sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -355,7 +355,7 @@ Expected precondition:
 sudo -u docdown-runner -H bash -lc '
   cd /opt/docdown-ops/releases/docdownops-main
   job_id=YOUR_JOB_ID
-  scripts/replay-job.sh ${job_id}
+  bash scripts/replay-job.sh ${job_id}
 '
 ```
 
@@ -365,7 +365,7 @@ Optional override (non-failed state only when intentionally required):
 sudo -u docdown-runner -H bash -lc '
   cd /opt/docdown-ops/releases/docdownops-main
   job_id=YOUR_JOB_ID
-  scripts/replay-job.sh ${job_id} --force
+  bash scripts/replay-job.sh ${job_id} --force
 '
 ```
 
@@ -388,12 +388,48 @@ Expected behavior:
 - next runner claim progresses state through `running -> succeeded|failed`
 - if sync is enabled, replay helper commits and pushes the queue/status update
 
-## 11) Current limitation to keep in mind
+## 11) Alert Threshold Configuration And Checks
+
+Use these settings to surface queue pressure and repeated sync failures in `docdownops-runner.service` logs.
+
+Suggested baseline in `/etc/default/docdownops-runner`:
+
+```bash
+cat >/tmp/docdownops-alert-thresholds.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo tee -a /etc/default/docdownops-runner >/dev/null <<'EOS'
+DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD=10
+DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD=900
+DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD=3
+DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS=60
+EOS
+
+sudo systemctl restart docdownops-runner.service
+EOF
+
+bash /tmp/docdownops-alert-thresholds.sh
+```
+
+Verification commands:
+
+```bash
+sudo systemctl status docdownops-runner.service --no-pager
+sudo journalctl -u docdownops-runner.service -n 200 --no-pager | grep 'ALERT:' || true
+```
+
+Expected behavior:
+- queue depth alert: `ALERT: queue depth ... exceeds threshold ...`
+- queue age alert: `ALERT: oldest queued job age ... exceeds threshold ...`
+- sync failure alert: `ALERT: sync failures reached ... during refresh|writeback`
+
+## 12) Current limitation to keep in mind
 
 With current scaffold, `runner-loop.sh` updates queue/status files in the local working copy.
 To make status globally visible through GitHub, ensure your operational process includes syncing these updates back to origin (for example, controlled commit/push flow or a wrapper service).
 
-## 12) Verified state as of 2026-04-15
+## 13) Verified state as of 2026-04-15
 
 - node01:
   - `/etc/default/docdownops-runner` exists.

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -209,12 +209,132 @@ sudo journalctl -u docdownops-runner.service -n 100 --no-pager
 sudo -u docdown-runner -H bash -lc 'cd /opt/docdown-ops/releases/docdownops-main && ls -la jobs/queued jobs/running jobs/done status'
 ```
 
-## 9) Current limitation to keep in mind
+## 9) Push-Conflict And Failed-Writeback Recovery
+
+Use this procedure when `docdownops-runner.service` logs show authenticated pull/push failures, non-fast-forward errors, or repeated writeback failures after a job has already been executed locally.
+
+1. Stabilize the active node
+
+```bash
+# Run on the active node (node01 normally, node02 during failover)
+sudo systemctl stop docdownops-runner.service
+sudo systemctl status docdownops-runner.service --no-pager || true
+sudo journalctl -u docdownops-runner.service -n 100 --no-pager
+```
+
+2. Inspect the repo state as `docdown-runner`
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  git status --short
+  git log --oneline --decorate -n 10 -- jobs status results
+  git rev-parse --abbrev-ref HEAD
+'
+```
+
+3. Decide which recovery path applies
+
+- Clean checkout, service only failed during refresh:
+  - run authenticated refresh and restart the service
+- Dirty checkout with local `jobs/`, `status/`, or `results/` changes:
+  - identify the affected `job_id`
+  - compare local changes with origin before deciding whether to push or discard them
+- Dirty checkout with unrelated files outside `jobs/`, `status/`, or `results/`:
+  - stop and inspect manually before restarting the service
+
+4. Recovery path A: checkout is clean, remote simply moved
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh pull task/10.2-runner-loop
+'
+
+sudo systemctl start docdownops-runner.service
+```
+
+5. Recovery path B: local writeback files exist, but origin may already have them
+
+First compare the local job files with origin:
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  job_id=YOUR_JOB_ID
+  git diff --name-status origin/task/10.2-runner-loop -- \
+    jobs/done/${job_id}.json \
+    status/${job_id}.json \
+    status/history/${job_id}.jsonl \
+    results/${job_id}
+'
+```
+
+If origin already contains the same terminal files for that `job_id`, discard the local duplicates and resync:
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh fetch task/10.2-runner-loop
+  git reset --hard origin/task/10.2-runner-loop
+'
+
+sudo systemctl start docdownops-runner.service
+```
+
+6. Recovery path C: local terminal files exist and origin is missing them
+
+If the job finished locally but the terminal manifest/status/results are only present on disk in the local checkout, push them explicitly:
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  job_id=YOUR_JOB_ID
+  git add \
+    jobs/done/${job_id}.json \
+    status/${job_id}.json \
+    status/history/${job_id}.jsonl \
+    results/${job_id}
+  git -c user.name="${DOCDOWN_GIT_COMMIT_NAME:-DocDownOps Runner}" \
+      -c user.email="${DOCDOWN_GIT_COMMIT_EMAIL:-docdownops-runner@local}" \
+      commit -m "Record ${job_id} succeeded"
+  scripts/git-github-app.sh pull task/10.2-runner-loop
+  scripts/git-github-app.sh push HEAD:task/10.2-runner-loop
+'
+
+sudo systemctl start docdownops-runner.service
+```
+
+7. Recovery path D: terminal job files are missing locally too
+
+- Inspect `/opt/docdown/workspace/jobs/<job_id>/summary.json` and the local logs first.
+- If the job actually failed before terminal writeback was prepared, treat it as a job replay/requeue case rather than a pure git recovery case.
+- Do not fabricate missing `results/` or `status/` files without first confirming the job outcome from the workspace.
+
+8. Post-recovery verification
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  git status --short
+  git log --oneline --decorate -n 5 -- jobs status results
+'
+
+sudo systemctl status docdownops-runner.service --no-pager
+sudo journalctl -u docdownops-runner.service -n 50 --no-pager
+```
+
+Expected healthy end state:
+- working tree is clean
+- branch is on `task/10.2-runner-loop` (or the current active delivery branch)
+- service is active and returns to `No queued jobs available to claim.` while idle
+
+## 10) Current limitation to keep in mind
 
 With current scaffold, `runner-loop.sh` updates queue/status files in the local working copy.
 To make status globally visible through GitHub, ensure your operational process includes syncing these updates back to origin (for example, controlled commit/push flow or a wrapper service).
 
-## 10) Verified state as of 2026-04-15
+## 11) Verified state as of 2026-04-15
 
 - node01:
   - `/etc/default/docdownops-runner` exists.

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -440,8 +440,9 @@ Expected behavior:
 
 ## 12) Current limitation to keep in mind
 
-With current scaffold, `runner-loop.sh` updates queue/status files in the local working copy.
-To make status globally visible through GitHub, ensure your operational process includes syncing these updates back to origin (for example, controlled commit/push flow or a wrapper service).
+`runner-loop.sh` always updates queue/status files in the local working copy first.
+When `DOCDOWN_GIT_SYNC_ENABLED=true`, the configured sync/writeback flow (`scripts/sync-state.sh`) commits and pushes those updates so status is globally visible through GitHub.
+If sync/writeback is disabled, status remains local-only until an operator performs manual commit/push or equivalent controlled sync.
 
 ## 13) Verified state as of 2026-04-15
 

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -35,7 +35,7 @@ Run from your operator shell on each node. The block below explicitly switches t
 
 If the executor script and related runner changes are not merged to `main` yet, use the active delivery branch instead of `main`. Current pre-merge branch:
 
-- `task/10.2-conversion-workflow`
+- `task/10.2-runner-loop`
 
 ```bash
 cat >/tmp/docdownops-clone-update.sh <<'EOF'
@@ -43,6 +43,7 @@ cat >/tmp/docdownops-clone-update.sh <<'EOF'
 set -euo pipefail
 
 DOCDOWNOPS_BRANCH="${DOCDOWNOPS_BRANCH:-task/10.2-conversion-workflow}"
+DOCDOWNOPS_BRANCH="${DOCDOWNOPS_BRANCH:-task/10.2-runner-loop}"
 
 sudo -u docdown-runner -H bash -lc '
   set -euo pipefail
@@ -185,3 +186,18 @@ sudo -u docdown-runner -H bash -lc 'cd /opt/docdown-ops/releases/docdownops-main
 
 With current scaffold, `runner-loop.sh` updates queue/status files in the local working copy.
 To make status globally visible through GitHub, ensure your operational process includes syncing these updates back to origin (for example, controlled commit/push flow or a wrapper service).
+
+## 10) Verified state as of 2026-04-15
+
+- node01:
+  - `/etc/default/docdownops-runner` exists.
+  - `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh` is present and executable.
+  - `docdownops-runner.service` is enabled and running.
+  - Healthy idle behavior is periodic `No queued jobs available to claim.` log entries while the service remains active.
+- node02:
+  - `/etc/default/docdownops-runner` exists.
+  - `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh` is present and executable.
+  - `docdownops-runner.service` remains disabled and inactive as standby default.
+
+Note:
+- If logs show `No queued jobs available to claim.` while the service stays active, that is normal idle polling behavior, not a fault condition.

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -1,0 +1,151 @@
+# DocDownOps Runner Setup (node01 primary, node02 standby)
+
+Purpose: run DocDownOps job processing on LAN hosts, with node01 active and node02 disabled standby.
+
+Important:
+- DocDownOps submit workflow currently runs on GitHub-hosted runner (`ubuntu-latest`).
+- The "runner" here means the local `scripts/runner-loop.sh` service, not a GitHub Actions self-hosted runner.
+- All command blocks are intended to be executed from an operator shell (for example `clusteradmin`), not by logging in directly as `docdown-runner`.
+- Where file ownership or git operations must run as `docdown-runner`, commands already use `sudo -u docdown-runner` explicitly.
+
+## 1) Host prerequisites (run on node01 and node02 as clusteradmin)
+
+```bash
+sudo apt-get update
+sudo apt-get install -y git python3
+
+sudo groupadd --force docdown-runner
+if ! id -u docdown-runner >/dev/null 2>&1; then
+  sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner
+fi
+
+sudo install -d -o docdown-runner -g docdown-runner /opt/docdown-ops
+sudo install -d -o docdown-runner -g docdown-runner /opt/docdown-ops/releases
+```
+
+## 2) Clone DocDownOps working tree
+
+Run from your operator shell on each node. The block below explicitly switches to `docdown-runner`. Replace clone URL if you use SSH.
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  set -euo pipefail
+  cd /opt/docdown-ops
+  if [ ! -d releases/docdownops-main/.git ]; then
+    git clone https://github.com/Frank-Yong/DocDownOps.git releases/docdownops-main
+  fi
+  cd releases/docdownops-main
+  git fetch origin
+  git checkout main
+  git pull --ff-only origin main
+'
+```
+
+## 3) Configure executor command (node01 and node02)
+
+`runner-loop.sh` requires `DOCDOWN_JOB_EXECUTOR` and will call it as:
+- `<executor> <manifest_path>`
+
+Create environment file:
+
+```bash
+sudo tee /etc/default/docdownops-runner >/dev/null <<'EOF'
+DOCDOWN_JOB_EXECUTOR=/usr/local/bin/docdown-execute-manifest
+EOF
+
+sudo chmod 640 /etc/default/docdownops-runner
+sudo chown root:docdown-runner /etc/default/docdownops-runner
+```
+
+Notes:
+- `DOCDOWN_JOB_EXECUTOR` must exist and be executable by `docdown-runner`.
+- Executor should return exit code 0 on success, non-zero on failure.
+- If executor prints a URL in stdout, runner-loop captures first URL into `result_url`.
+
+## 4) Install systemd service for runner-loop
+
+```bash
+sudo tee /etc/systemd/system/docdownops-runner.service >/dev/null <<'EOF'
+[Unit]
+Description=DocDownOps Runner Loop
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=docdown-runner
+Group=docdown-runner
+WorkingDirectory=/opt/docdown-ops/releases/docdownops-main
+EnvironmentFile=/etc/default/docdownops-runner
+ExecStart=/usr/bin/env bash scripts/runner-loop.sh --poll-interval-seconds 10
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+```
+
+## 5) Node01 primary mode
+
+Enable and start on node01:
+
+```bash
+# Run on node01
+sudo systemctl enable docdownops-runner.service
+sudo systemctl start docdownops-runner.service
+sudo systemctl status docdownops-runner.service --no-pager
+```
+
+## 6) Node02 standby mode
+
+Disable and stop on node02 (recommended default):
+
+```bash
+# Run on node02
+sudo systemctl disable docdownops-runner.service
+sudo systemctl stop docdownops-runner.service || true
+sudo systemctl status docdownops-runner.service --no-pager || true
+```
+
+## 7) Failover procedure
+
+When node01 is unavailable, activate node02:
+
+```bash
+# Run on node02
+sudo systemctl enable docdownops-runner.service
+sudo systemctl start docdownops-runner.service
+sudo systemctl status docdownops-runner.service --no-pager
+```
+
+When node01 is recovered, return to normal posture:
+
+```bash
+# Run on node02
+sudo systemctl stop docdownops-runner.service
+sudo systemctl disable docdownops-runner.service
+
+# Run on node01
+sudo systemctl start docdownops-runner.service
+```
+
+## 8) Basic runtime checks
+
+```bash
+# Service health
+sudo systemctl status docdownops-runner.service --no-pager
+
+# Recent logs
+sudo journalctl -u docdownops-runner.service -n 100 --no-pager
+
+# Queue/status files in working copy
+sudo -u docdown-runner -H bash -lc 'cd /opt/docdown-ops/releases/docdownops-main && ls -la jobs/queued jobs/running jobs/done status'
+```
+
+## 9) Current limitation to keep in mind
+
+With current scaffold, `runner-loop.sh` updates queue/status files in the local working copy.
+To make status globally visible through GitHub, ensure your operational process includes syncing these updates back to origin (for example, controlled commit/push flow or a wrapper service).

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -403,12 +403,22 @@ cat >/tmp/docdownops-alert-thresholds.sh <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo tee -a /etc/default/docdownops-runner >/dev/null <<'EOS'
-DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD=10
-DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD=900
-DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD=3
-DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS=60
-EOS
+sudo bash -c '
+  env_file=/etc/default/docdownops-runner
+  touch "$env_file"
+  ensure_kv() {
+    local key="$1"
+    local value="$2"
+    if ! grep -Eq "^[[:space:]]*${key}=" "$env_file"; then
+      printf "%s=%s\n" "$key" "$value" >> "$env_file"
+    fi
+  }
+
+  ensure_kv DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD 10
+  ensure_kv DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD 900
+  ensure_kv DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD 3
+  ensure_kv DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS 60
+'
 
 sudo systemctl restart docdownops-runner.service
 EOF

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -42,7 +42,6 @@ cat >/tmp/docdownops-clone-update.sh <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCDOWNOPS_BRANCH="${DOCDOWNOPS_BRANCH:-task/10.2-conversion-workflow}"
 DOCDOWNOPS_BRANCH="${DOCDOWNOPS_BRANCH:-task/10.2-runner-loop}"
 
 sudo -u docdown-runner -H bash -lc '

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -33,10 +33,16 @@ bash /tmp/docdownops-host-prereq.sh
 
 Run from your operator shell on each node. The block below explicitly switches to `docdown-runner`. Replace clone URL if you use SSH.
 
+If the executor script and related runner changes are not merged to `main` yet, use the active delivery branch instead of `main`. Current pre-merge branch:
+
+- `task/10.2-conversion-workflow`
+
 ```bash
 cat >/tmp/docdownops-clone-update.sh <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+DOCDOWNOPS_BRANCH="${DOCDOWNOPS_BRANCH:-task/10.2-conversion-workflow}"
 
 sudo -u docdown-runner -H bash -lc '
   set -euo pipefail
@@ -46,13 +52,15 @@ sudo -u docdown-runner -H bash -lc '
   fi
   cd releases/docdownops-main
   git fetch origin
-  git checkout main
-  git pull --ff-only origin main
+  git checkout '"'"'${DOCDOWNOPS_BRANCH}'"'"'
+  git pull --ff-only origin '"'"'${DOCDOWNOPS_BRANCH}'"'"'
 '
 EOF
 
 bash /tmp/docdownops-clone-update.sh
 ```
+
+Once the branch is merged, set `DOCDOWNOPS_BRANCH=main` before running the same block, or edit the default branch in the temporary script.
 
 ## 3) Configure executor command (node01 and node02)
 

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -7,20 +7,26 @@ Important:
 - The "runner" here means the local `scripts/runner-loop.sh` service, not a GitHub Actions self-hosted runner.
 - All command blocks are intended to be executed from an operator shell (for example `clusteradmin`), not by logging in directly as `docdown-runner`.
 - Where file ownership or git operations must run as `docdown-runner`, commands already use `sudo -u docdown-runner` explicitly.
+- Paste-safe pattern: each section writes a temporary script file and executes it to avoid broken multi-line paste in SSH terminals.
 
 ## 1) Host prerequisites (run on node01 and node02 as clusteradmin)
 
 ```bash
+cat >/tmp/docdownops-host-prereq.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
 sudo apt-get update
 sudo apt-get install -y git python3
 
 sudo groupadd --force docdown-runner
-if ! id -u docdown-runner >/dev/null 2>&1; then
-  sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner
-fi
+id -u docdown-runner >/dev/null 2>&1 || sudo useradd --create-home --shell /bin/bash --gid docdown-runner docdown-runner
 
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown-ops
 sudo install -d -o docdown-runner -g docdown-runner /opt/docdown-ops/releases
+EOF
+
+bash /tmp/docdownops-host-prereq.sh
 ```
 
 ## 2) Clone DocDownOps working tree
@@ -28,6 +34,10 @@ sudo install -d -o docdown-runner -g docdown-runner /opt/docdown-ops/releases
 Run from your operator shell on each node. The block below explicitly switches to `docdown-runner`. Replace clone URL if you use SSH.
 
 ```bash
+cat >/tmp/docdownops-clone-update.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
 sudo -u docdown-runner -H bash -lc '
   set -euo pipefail
   cd /opt/docdown-ops
@@ -39,6 +49,9 @@ sudo -u docdown-runner -H bash -lc '
   git checkout main
   git pull --ff-only origin main
 '
+EOF
+
+bash /tmp/docdownops-clone-update.sh
 ```
 
 ## 3) Configure executor command (node01 and node02)
@@ -49,12 +62,19 @@ sudo -u docdown-runner -H bash -lc '
 Create environment file:
 
 ```bash
-sudo tee /etc/default/docdownops-runner >/dev/null <<'EOF'
+cat >/tmp/docdownops-env-setup.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo tee /etc/default/docdownops-runner >/dev/null <<'EOS'
 DOCDOWN_JOB_EXECUTOR=/usr/local/bin/docdown-execute-manifest
-EOF
+EOS
 
 sudo chmod 640 /etc/default/docdownops-runner
 sudo chown root:docdown-runner /etc/default/docdownops-runner
+EOF
+
+bash /tmp/docdownops-env-setup.sh
 ```
 
 Notes:
@@ -65,7 +85,11 @@ Notes:
 ## 4) Install systemd service for runner-loop
 
 ```bash
-sudo tee /etc/systemd/system/docdownops-runner.service >/dev/null <<'EOF'
+cat >/tmp/docdownops-systemd-setup.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo tee /etc/systemd/system/docdownops-runner.service >/dev/null <<'EOS'
 [Unit]
 Description=DocDownOps Runner Loop
 After=network-online.target
@@ -83,9 +107,12 @@ RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
-EOF
+EOS
 
 sudo systemctl daemon-reload
+EOF
+
+bash /tmp/docdownops-systemd-setup.sh
 ```
 
 ## 5) Node01 primary mode

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -76,6 +76,9 @@ set -euo pipefail
 
 sudo tee /etc/default/docdownops-runner >/dev/null <<'EOS'
 DOCDOWN_JOB_EXECUTOR=/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh
+DOCDOWN_GIT_SYNC_ENABLED=true
+DOCDOWN_GIT_COMMIT_NAME=DocDownOps Runner
+DOCDOWN_GIT_COMMIT_EMAIL=docdownops-runner@local
 EOS
 
 sudo chmod 640 /etc/default/docdownops-runner
@@ -88,6 +91,8 @@ bash /tmp/docdownops-env-setup.sh
 Notes:
 - `DOCDOWN_JOB_EXECUTOR` must exist and be executable by `docdown-runner`.
 - Current repo-managed V1 path: `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+- `DOCDOWN_GIT_SYNC_ENABLED=true` enables status/result writeback to origin, which the rest of this runbook assumes.
+- `DOCDOWN_GIT_COMMIT_NAME` and `DOCDOWN_GIT_COMMIT_EMAIL` keep runner-authored sync commits deterministic.
 - Executor should return exit code 0 on success, non-zero on failure.
 - If executor prints a URL in stdout, runner-loop captures first URL into `result_url`.
 

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -67,7 +67,7 @@ cat >/tmp/docdownops-env-setup.sh <<'EOF'
 set -euo pipefail
 
 sudo tee /etc/default/docdownops-runner >/dev/null <<'EOS'
-DOCDOWN_JOB_EXECUTOR=/usr/local/bin/docdown-execute-manifest
+DOCDOWN_JOB_EXECUTOR=/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh
 EOS
 
 sudo chmod 640 /etc/default/docdownops-runner
@@ -79,6 +79,7 @@ bash /tmp/docdownops-env-setup.sh
 
 Notes:
 - `DOCDOWN_JOB_EXECUTOR` must exist and be executable by `docdown-runner`.
+- Current repo-managed V1 path: `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
 - Executor should return exit code 0 on success, non-zero on failure.
 - If executor prints a URL in stdout, runner-loop captures first URL into `result_url`.
 

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -166,7 +166,34 @@ sudo systemctl stop docdownops-runner.service
 sudo systemctl disable docdownops-runner.service
 
 # Run on node01
+sudo systemctl enable docdownops-runner.service
 sudo systemctl start docdownops-runner.service
+```
+
+Operator note:
+- If the checkout is behind on either node, update it as `docdown-runner` before starting the service.
+- Prefer `git reset --hard origin/<branch>` over interactive `git pull` when recovering a host-local checkout to a known branch tip.
+
+Credential-free operator maintenance commands:
+
+```bash
+# Run on node01 or node02 from the clusteradmin shell
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh fetch task/10.2-runner-loop
+  git checkout task/10.2-runner-loop
+  git reset --hard origin/task/10.2-runner-loop
+  git rev-parse --short HEAD
+'
+```
+
+For an authenticated fast-forward pull without the username/password prompt:
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh pull task/10.2-runner-loop
+'
 ```
 
 ## 8) Basic runtime checks
@@ -192,12 +219,21 @@ To make status globally visible through GitHub, ensure your operational process 
 - node01:
   - `/etc/default/docdownops-runner` exists.
   - `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh` is present and executable.
-  - `docdownops-runner.service` is enabled and running.
+  - `docdownops-runner.service` was validated as the primary active runner and can be returned to that posture after failover tests.
   - Healthy idle behavior is periodic `No queued jobs available to claim.` log entries while the service remains active.
 - node02:
   - `/etc/default/docdownops-runner` exists.
   - `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh` is present and executable.
-  - `docdownops-runner.service` remains disabled and inactive as standby default.
+  - `docdownops-runner.service` remains disabled and inactive as standby default outside failover tests, but was validated successfully as the active runner during the 2026-04-15 failover exercise.
+
+Validated failover result:
+- node01 was stopped/disabled, node02 was enabled/started, and workflow-dispatched job `20260415102641-543c64` completed successfully through node02.
+- Remote writeback preserved the same behavior under failover:
+  - commit `c79da5f` enqueued the job
+  - commit `2433b52` marked it running
+  - commit `0ec5b17` recorded success
+  - `status/20260415102641-543c64.json` includes `result_url = https://github.com/Frank-Yong/DocDownOps/tree/task/10.2-runner-loop/results/20260415102641-543c64`
+  - `results/20260415102641-543c64/final.md` exists in the repo
 
 Note:
 - If logs show `No queued jobs available to claim.` while the service stays active, that is normal idle polling behavior, not a fault condition.

--- a/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
+++ b/docs/notes/2026-04-14_16-20-00-docdownops-runner-setup.md
@@ -329,12 +329,71 @@ Expected healthy end state:
 - branch is on `task/10.2-runner-loop` (or the current active delivery branch)
 - service is active and returns to `No queued jobs available to claim.` while idle
 
-## 10) Current limitation to keep in mind
+## 10) Replay Failed Job By Job Id
+
+Use this when a failed job should be replayed with the same manifest after fixing environment/config/runtime conditions.
+
+1. Verify terminal failed state and identify target job id
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  job_id=YOUR_JOB_ID
+  cat status/${job_id}.json
+  test -f jobs/done/${job_id}.json
+'
+```
+
+Expected precondition:
+- `status/<job_id>.json` shows `"state": "failed"`
+- `jobs/done/<job_id>.json` exists
+- no same-id manifest under `jobs/queued/` or `jobs/running/`
+
+2. Replay the job back to queue
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  job_id=YOUR_JOB_ID
+  scripts/replay-job.sh ${job_id}
+'
+```
+
+Optional override (non-failed state only when intentionally required):
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  job_id=YOUR_JOB_ID
+  scripts/replay-job.sh ${job_id} --force
+'
+```
+
+3. Verify replay writeback and reprocessing
+
+```bash
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  job_id=YOUR_JOB_ID
+  ls -la jobs/queued/${job_id}.json
+  tail -n 3 status/history/${job_id}.jsonl
+'
+
+sudo systemctl status docdownops-runner.service --no-pager
+sudo journalctl -u docdownops-runner.service -n 50 --no-pager
+```
+
+Expected behavior:
+- replay helper appends a new `queued` transition with message `Manual replay requested for job_id <job_id>`
+- next runner claim progresses state through `running -> succeeded|failed`
+- if sync is enabled, replay helper commits and pushes the queue/status update
+
+## 11) Current limitation to keep in mind
 
 With current scaffold, `runner-loop.sh` updates queue/status files in the local working copy.
 To make status globally visible through GitHub, ensure your operational process includes syncing these updates back to origin (for example, controlled commit/push flow or a wrapper service).
 
-## 11) Verified state as of 2026-04-15
+## 12) Verified state as of 2026-04-15
 
 - node01:
   - `/etc/default/docdownops-runner` exists.

--- a/docs/notes/2026-04-21_14-34-00.md
+++ b/docs/notes/2026-04-21_14-34-00.md
@@ -1,0 +1,90 @@
+1. Confirm the code you want to deploy
+```powershell
+# Local workstation (optional sanity check)
+cd F:\Users\email\repos\DocDownOps
+git status
+git log --oneline -n 5
+```
+
+2. Roll out to node01 (active runner)
+```bash
+# On node01 as clusteradmin
+sudo -u docdown-runner -H bash -lc '
+  set -euo pipefail
+  set -a
+  source /etc/default/docdownops-runner
+  set +a
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh fetch task/10.2-runner-loop
+  git checkout task/10.2-runner-loop
+  git reset --hard origin/task/10.2-runner-loop
+  git rev-parse --short HEAD
+'
+```
+
+3. Ensure env has new knobs (or keep defaults)
+```bash
+# On node01 as clusteradmin
+sudo tee -a /etc/default/docdownops-runner >/dev/null <<'EOS'
+# Optional alert defaults
+DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD=10
+DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD=900
+DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD=3
+DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS=60
+
+# Optional retention defaults (if not already set)
+DOCDOWN_RETENTION_ENABLED=true
+DOCDOWN_RETENTION_RUN_INTERVAL_SECONDS=3600
+DOCDOWN_RETENTION_DONE_DAYS=30
+DOCDOWN_RETENTION_STATUS_DAYS=30
+DOCDOWN_RETENTION_STATUS_HISTORY_DAYS=30
+DOCDOWN_RETENTION_RESULTS_DAYS=30
+EOS
+```
+
+4. Restart and verify node01 service
+```bash
+sudo systemctl restart docdownops-runner.service
+sudo systemctl status docdownops-runner.service --no-pager
+sudo journalctl -u docdownops-runner.service -n 120 --no-pager
+```
+
+5. Verify expected runtime behavior
+```bash
+# Should show healthy polling when idle
+sudo journalctl -u docdownops-runner.service -n 200 --no-pager | grep -E 'No queued jobs available|ALERT:' || true
+```
+
+6. Keep node02 as standby, but update its checkout too
+```bash
+# On node02 as clusteradmin
+sudo systemctl stop docdownops-runner.service || true
+sudo systemctl disable docdownops-runner.service || true
+
+sudo -u docdown-runner -H bash -lc '
+  set -euo pipefail
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh fetch task/10.2-runner-loop
+  git checkout task/10.2-runner-loop
+  git reset --hard origin/task/10.2-runner-loop
+  git rev-parse --short HEAD
+'
+```
+
+7. Quick functional smoke test (recommended)
+```bash
+# Submit one workflow_dispatch job and confirm in DocDownOps repo:
+# - queued -> running -> succeeded|failed
+# - jobs/done/<job_id>.json exists
+# - status/<job_id>.json includes expected fields/result_url
+```
+
+8. Rollback plan (if needed)
+```bash
+# On affected node
+sudo -u docdown-runner -H bash -lc '
+  cd /opt/docdown-ops/releases/docdownops-main
+  scripts/git-github-app.sh fetch task/10.2-runner-loop
+  git reset --hard <previous_good_commit_sha>
+'
+sudo systemctl restart docdownops-runner.service

--- a/docs/notes/2026-04-21_14-34-00.md
+++ b/docs/notes/2026-04-21_14-34-00.md
@@ -1,7 +1,7 @@
 1. Confirm the code you want to deploy
 ```powershell
 # Local workstation (optional sanity check)
-cd F:\Users\email\repos\DocDownOps
+cd "$env:USERPROFILE\repos\DocDownOps"
 git status
 git log --oneline -n 5
 ```

--- a/docs/notes/2026-04-21_14-34-00.md
+++ b/docs/notes/2026-04-21_14-34-00.md
@@ -23,23 +23,36 @@
    ```
 
 3. Ensure env has new knobs (or keep defaults)
+
+   This step is idempotent: each key is appended only if it is not already present in `/etc/default/docdownops-runner`. Re-running will not duplicate keys. To change an existing value, edit the file directly instead of re-running this block.
+
    ```bash
    # On node01 as clusteradmin
-   sudo tee -a /etc/default/docdownops-runner >/dev/null <<'EOS'
-   # Optional alert defaults
-   DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD=10
-   DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD=900
-   DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD=3
-   DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS=60
+   sudo bash -c '
+     env_file=/etc/default/docdownops-runner
+     touch "$env_file"
+     ensure_kv() {
+       local key="$1"
+       local value="$2"
+       if ! grep -Eq "^[[:space:]]*${key}=" "$env_file"; then
+         printf "%s=%s\n" "$key" "$value" >> "$env_file"
+       fi
+     }
 
-   # Optional retention defaults (if not already set)
-   DOCDOWN_RETENTION_ENABLED=true
-   DOCDOWN_RETENTION_RUN_INTERVAL_SECONDS=3600
-   DOCDOWN_RETENTION_DONE_DAYS=30
-   DOCDOWN_RETENTION_STATUS_DAYS=30
-   DOCDOWN_RETENTION_STATUS_HISTORY_DAYS=30
-   DOCDOWN_RETENTION_RESULTS_DAYS=30
-   EOS
+     # Optional alert defaults
+     ensure_kv DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD 10
+     ensure_kv DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD 900
+     ensure_kv DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD 3
+     ensure_kv DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS 60
+
+     # Optional retention defaults (if not already set)
+     ensure_kv DOCDOWN_RETENTION_ENABLED true
+     ensure_kv DOCDOWN_RETENTION_RUN_INTERVAL_SECONDS 3600
+     ensure_kv DOCDOWN_RETENTION_DONE_DAYS 30
+     ensure_kv DOCDOWN_RETENTION_STATUS_DAYS 30
+     ensure_kv DOCDOWN_RETENTION_STATUS_HISTORY_DAYS 30
+     ensure_kv DOCDOWN_RETENTION_RESULTS_DAYS 30
+   '
    ```
 
 4. Restart and verify node01 service

--- a/docs/notes/2026-04-21_14-34-00.md
+++ b/docs/notes/2026-04-21_14-34-00.md
@@ -98,6 +98,8 @@
    sudo -u docdown-runner -H bash -lc '
      cd /opt/docdown-ops/releases/docdownops-main
      scripts/git-github-app.sh fetch task/10.2-runner-loop
+       git checkout task/10.2-runner-loop
+       git rev-parse --abbrev-ref HEAD
      git reset --hard <previous_good_commit_sha>
    '
    sudo systemctl restart docdownops-runner.service

--- a/docs/notes/2026-04-21_14-34-00.md
+++ b/docs/notes/2026-04-21_14-34-00.md
@@ -1,91 +1,91 @@
 1. Confirm the code you want to deploy
-```powershell
-# Local workstation (optional sanity check)
-cd "$env:USERPROFILE\repos\DocDownOps"
-git status
-git log --oneline -n 5
-```
+   ```powershell
+   # Local workstation (optional sanity check)
+   cd "$env:USERPROFILE\repos\DocDownOps"
+   git status
+   git log --oneline -n 5
+   ```
 
 2. Roll out to node01 (active runner)
-```bash
-# On node01 as clusteradmin
-sudo -u docdown-runner -H bash -lc '
-  set -euo pipefail
-  set -a
-  source /etc/default/docdownops-runner
-  set +a
-  cd /opt/docdown-ops/releases/docdownops-main
-  scripts/git-github-app.sh fetch task/10.2-runner-loop
-  git checkout task/10.2-runner-loop
-  git reset --hard origin/task/10.2-runner-loop
-  git rev-parse --short HEAD
-'
-```
+   ```bash
+   # On node01 as clusteradmin
+   sudo -u docdown-runner -H bash -lc '
+     set -euo pipefail
+     set -a
+     source /etc/default/docdownops-runner
+     set +a
+     cd /opt/docdown-ops/releases/docdownops-main
+     scripts/git-github-app.sh fetch task/10.2-runner-loop
+     git checkout task/10.2-runner-loop
+     git reset --hard origin/task/10.2-runner-loop
+     git rev-parse --short HEAD
+   '
+   ```
 
 3. Ensure env has new knobs (or keep defaults)
-```bash
-# On node01 as clusteradmin
-sudo tee -a /etc/default/docdownops-runner >/dev/null <<'EOS'
-# Optional alert defaults
-DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD=10
-DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD=900
-DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD=3
-DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS=60
+   ```bash
+   # On node01 as clusteradmin
+   sudo tee -a /etc/default/docdownops-runner >/dev/null <<'EOS'
+   # Optional alert defaults
+   DOCDOWN_ALERT_QUEUE_DEPTH_THRESHOLD=10
+   DOCDOWN_ALERT_QUEUED_AGE_SECONDS_THRESHOLD=900
+   DOCDOWN_ALERT_SYNC_FAILURE_THRESHOLD=3
+   DOCDOWN_ALERT_CHECK_INTERVAL_SECONDS=60
 
-# Optional retention defaults (if not already set)
-DOCDOWN_RETENTION_ENABLED=true
-DOCDOWN_RETENTION_RUN_INTERVAL_SECONDS=3600
-DOCDOWN_RETENTION_DONE_DAYS=30
-DOCDOWN_RETENTION_STATUS_DAYS=30
-DOCDOWN_RETENTION_STATUS_HISTORY_DAYS=30
-DOCDOWN_RETENTION_RESULTS_DAYS=30
-EOS
-```
+   # Optional retention defaults (if not already set)
+   DOCDOWN_RETENTION_ENABLED=true
+   DOCDOWN_RETENTION_RUN_INTERVAL_SECONDS=3600
+   DOCDOWN_RETENTION_DONE_DAYS=30
+   DOCDOWN_RETENTION_STATUS_DAYS=30
+   DOCDOWN_RETENTION_STATUS_HISTORY_DAYS=30
+   DOCDOWN_RETENTION_RESULTS_DAYS=30
+   EOS
+   ```
 
 4. Restart and verify node01 service
-```bash
-sudo systemctl restart docdownops-runner.service
-sudo systemctl status docdownops-runner.service --no-pager
-sudo journalctl -u docdownops-runner.service -n 120 --no-pager
-```
+   ```bash
+   sudo systemctl restart docdownops-runner.service
+   sudo systemctl status docdownops-runner.service --no-pager
+   sudo journalctl -u docdownops-runner.service -n 120 --no-pager
+   ```
 
 5. Verify expected runtime behavior
-```bash
-# Should show healthy polling when idle
-sudo journalctl -u docdownops-runner.service -n 200 --no-pager | grep -E 'No queued jobs available|ALERT:' || true
-```
+   ```bash
+   # Should show healthy polling when idle
+   sudo journalctl -u docdownops-runner.service -n 200 --no-pager | grep -E 'No queued jobs available|ALERT:' || true
+   ```
 
 6. Keep node02 as standby, but update its checkout too
-```bash
-# On node02 as clusteradmin
-sudo systemctl stop docdownops-runner.service || true
-sudo systemctl disable docdownops-runner.service || true
+   ```bash
+   # On node02 as clusteradmin
+   sudo systemctl stop docdownops-runner.service || true
+   sudo systemctl disable docdownops-runner.service || true
 
-sudo -u docdown-runner -H bash -lc '
-  set -euo pipefail
-  cd /opt/docdown-ops/releases/docdownops-main
-  scripts/git-github-app.sh fetch task/10.2-runner-loop
-  git checkout task/10.2-runner-loop
-  git reset --hard origin/task/10.2-runner-loop
-  git rev-parse --short HEAD
-'
-```
+   sudo -u docdown-runner -H bash -lc '
+     set -euo pipefail
+     cd /opt/docdown-ops/releases/docdownops-main
+     scripts/git-github-app.sh fetch task/10.2-runner-loop
+     git checkout task/10.2-runner-loop
+     git reset --hard origin/task/10.2-runner-loop
+     git rev-parse --short HEAD
+   '
+   ```
 
 7. Quick functional smoke test (recommended)
-```bash
-# Submit one workflow_dispatch job and confirm in DocDownOps repo:
-# - queued -> running -> succeeded|failed
-# - jobs/done/<job_id>.json exists
-# - status/<job_id>.json includes expected fields/result_url
-```
+   ```bash
+   # Submit one workflow_dispatch job and confirm in DocDownOps repo:
+   # - queued -> running -> succeeded|failed
+   # - jobs/done/<job_id>.json exists
+   # - status/<job_id>.json includes expected fields/result_url
+   ```
 
 8. Rollback plan (if needed)
-```bash
-# On affected node
-sudo -u docdown-runner -H bash -lc '
-  cd /opt/docdown-ops/releases/docdownops-main
-  scripts/git-github-app.sh fetch task/10.2-runner-loop
-  git reset --hard <previous_good_commit_sha>
-'
-sudo systemctl restart docdownops-runner.service
-```
+   ```bash
+   # On affected node
+   sudo -u docdown-runner -H bash -lc '
+     cd /opt/docdown-ops/releases/docdownops-main
+     scripts/git-github-app.sh fetch task/10.2-runner-loop
+     git reset --hard <previous_good_commit_sha>
+   '
+   sudo systemctl restart docdownops-runner.service
+   ```

--- a/docs/notes/2026-04-21_14-34-00.md
+++ b/docs/notes/2026-04-21_14-34-00.md
@@ -88,3 +88,4 @@ sudo -u docdown-runner -H bash -lc '
   git reset --hard <previous_good_commit_sha>
 '
 sudo systemctl restart docdownops-runner.service
+```

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -255,7 +255,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 6. Status And Result Publication
   - [x] Publish `running`, `succeeded`, `failed`, and `retrying` states back to DocDownOps origin.
-  - [ ] Preserve attempt counts across retries.
+  - [x] Preserve attempt counts across retries.
   - [x] Append status transitions to `status/history/<job_id>.jsonl`.
   - [x] Publish submitter-visible result link (`artifact`, `commit`, or `pr`).
   - [ ] Ensure failed jobs include a usable diagnostic message/log pointer.
@@ -273,7 +273,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Preserve attempt counts across retries and include a stronger diagnostic pointer for failed jobs.
+3. Include a stronger diagnostic pointer for failed jobs.
 
 8. Operational Hardening
   - [ ] Add stuck-job detection for aged entries in `jobs/running/`.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -27,26 +27,138 @@ This task focuses on runtime operations for conversion jobs, not repository vali
 
 The goal is to make conversion execution operationally safe in production. CI/CD should deploy and restart runtime components, while this task defines and stabilizes how conversion work is accepted, processed, and observed.
 
+### Operating Constraint
+
+- Conversion execution remains on a local self-hosted runner in LAN.
+- Submission and status must be available from anywhere with GitHub access.
+- Therefore, runtime orchestration should use GitHub as the control plane and local runner as the execution plane.
+
+### Recommended V1 Architecture
+
+- `docdown-ops` (or equivalent operations repo) hosts job manifests and status updates.
+- Submitters create jobs through GitHub-facing channels:
+  - workflow dispatch
+  - issue/PR command
+  - CLI that writes job manifests to ops repo
+- Local runner polls/claims jobs from ops repo and performs conversion.
+- Results are published back to GitHub (artifacts and/or commit/PR), so submitter can access markdown remotely.
+
+```mermaid
+flowchart LR
+    U[Submitter Anywhere] --> G[GitHub API or Ops Repo]
+    G --> Q[Job Manifest Queue]
+    Q --> R[Local LAN Runner Claims Job]
+    R --> C[DocDown Conversion]
+    C --> A[Result Artifacts and Logs]
+    A --> G
+    G --> U
+```
+
 ### Recommended Baseline
 
 - Intake:
-  - watched folder, API endpoint, or manual enqueue command
+  - `source.type = git` for v1 default (repo/ref/path)
+  - optional `source.type = upload` through CLI helper that uploads to intake repo
 - Queue:
-  - Redis-backed queue (or SQLite queue for low load)
+  - git-backed job manifests in ops repo (`jobs/queued/*.json`)
 - Worker:
-  - isolated workdir per job
-  - deterministic processing path
+  - local runner claims by moving manifest to `jobs/running/`
+  - isolated workdir per job (`/opt/docdown/workspace/jobs/<job_id>`)
 - Artifacts:
-  - stable per-job output path with timestamps and logs
+  - per-job output tree containing staged input, final markdown, logs, run summary
+  - publish result pointer back to job status in ops repo
 - Observability:
-  - status list command/dashboard
-  - queue depth, failure rate, runtime metrics
+  - status file per job (`queued`, `running`, `succeeded`, `failed`, `retrying`)
+  - queue depth and age derived from queued manifests
+
+### Job Contract (V1)
+
+Job manifest fields:
+
+- `job_id`: unique id (`YYYYMMDDHHMMSS-<shortsha>-<nonce>`)
+- `submitted_at`, `submitted_by`
+- `source`:
+  - `type`: `git` | `upload`
+  - `repo`, `ref`, `path` (for `git`)
+  - `artifact_ref` (for `upload`)
+- `options`:
+  - profile/config overrides allowed by policy
+- `idempotency_key`:
+  - hash of source locator + options
+- `result`:
+  - output target mode (`artifact` | `commit` | `pr`)
+
+### Job Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued
+    queued --> running: claim
+    running --> succeeded: conversion ok
+    running --> failed: deterministic error
+    running --> retrying: transient error
+    retrying --> queued: retry delay elapsed
+    retrying --> failed: max attempts reached
+    succeeded --> [*]
+    failed --> [*]
+```
+
+Retry policy:
+
+- Retry transient classes only (git clone timeout, network reset, temporary disk pressure).
+- Do not retry deterministic classes (invalid PDF, unsupported input, policy violation).
+- Include attempt count and last error classification in job status.
+
+### Artifact And Traceability Layout
+
+Per job root:
+
+- `input/`: staged source PDF
+- `output/final.md`: final markdown deliverable
+- `output/assets/`: extracted images or attachments
+- `logs/run.log`: execution log
+- `logs/stderr.log`: stderr capture
+- `summary.json`: timings, versions, exit status, hash metadata
+
+### Submitter Access Model
+
+- Submitter receives `job_id` immediately.
+- Submitter checks status via GitHub-visible job status file or status endpoint.
+- On success, submitter gets direct markdown location:
+  - artifact download URL, or
+  - commit/PR URL containing generated markdown.
+
+### Security And Access Policy
+
+- Allowlist repos for `source.type = git`.
+- Use least-privilege token or GitHub App installation for read/write operations.
+- Do not read arbitrary LAN-local submitter paths directly from remote requests.
+- Treat upload helper as explicit handoff into GitHub-accessible storage.
+
+### Operational Limits (Initial Defaults)
+
+- Max PDF size: 150 MB
+- Max pages: 1500
+- Max wall-clock per job: 30 minutes
+- Max concurrent jobs per runner: 1 (increase after soak)
+- Retention:
+  - keep last 30 days of artifacts
+  - keep failure logs for 60 days
 
 ### Integration Boundary With Task 10.1
 
 - Task 10.1 provides CI/CD pipelines and deployment mechanics.
 - Task 10.2 provides runtime conversion orchestration and operations policy.
 - CD should restart or reload the conversion service defined in this task.
+
+### Delivery Plan (V1)
+
+1. Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
+2. Implement submit path (`workflow_dispatch` + JSON manifest validation).
+3. Implement claim/lock behavior on local runner.
+4. Implement conversion executor with standardized artifact layout.
+5. Publish status transitions and result links to submitter-visible location.
+6. Add runbook for restart, stuck-job recovery, and replay by `job_id`.
 
 ## References
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -273,13 +273,13 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Define alert thresholds for queue depth, job age, and repeated push failures.
+3. Continue operational soak and adjust retry/retention/alert thresholds from observed production behavior.
 
 8. Operational Hardening
   - [x] Add stuck-job detection for aged entries in `jobs/running/`.
   - [x] Add replay-by-`job_id` operational procedure for failed jobs.
   - [x] Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
-  - [ ] Define alert thresholds for queue depth, job age, and repeated push failures.
+  - [x] Define alert thresholds for queue depth, job age, and repeated push failures.
 
 ## References
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -273,11 +273,11 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Add replay-by-`job_id` operational procedure for failed jobs.
+3. Define alert thresholds for queue depth, job age, and repeated push failures.
 
 8. Operational Hardening
   - [x] Add stuck-job detection for aged entries in `jobs/running/`.
-  - [ ] Add replay-by-`job_id` operational procedure for failed jobs.
+  - [x] Add replay-by-`job_id` operational procedure for failed jobs.
   - [x] Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
   - [ ] Define alert thresholds for queue depth, job age, and repeated push failures.
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -165,3 +165,4 @@ Per job root:
 - [task-10.0-ci-cd-prerequisites.md](task-10.0-ci-cd-prerequisites.md)
 - [task-10.1-ci-cd-pipeline.md](task-10.1-ci-cd-pipeline.md)
 - [../technical-design.md](../technical-design.md)
+- [../notes/2026-04-14_07-10-00.md](../notes/2026-04-14_07-10-00.md)

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -177,13 +177,18 @@ Per job root:
   - DocDownOps repo clone exists.
   - `/etc/default/docdownops-runner` exists.
   - `docdownops-runner.service` is installed and enabled.
-  - `docdownops-runner.service` is currently inactive.
-  - Repo-managed executor script should be installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+  - `docdownops-runner.service` is active and polling normally on a 10-second interval.
+  - Repo-managed executor script is installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+  - `runner-loop.sh` was corrected so `claim-job.sh` exit code `3` (`no queued jobs`) is treated as idle sleep instead of service failure.
+  - GitHub App credentials are installed outside the repository and readable by `docdown-runner`.
+  - GitHub App token minting and authenticated `git fetch` against `Frank-Yong/DocDownOps` are verified.
 - Task 10.2 / node02:
   - DocDownOps repo clone exists.
+  - `/etc/default/docdownops-runner` exists.
   - `docdownops-runner.service` is installed, disabled, and inactive as intended for standby.
-  - `/etc/default/docdownops-runner` is missing.
-  - Repo-managed executor script should be installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+  - Repo-managed executor script is installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+  - GitHub App credentials are installed outside the repository and readable by `docdown-runner`.
+  - GitHub App token minting and authenticated `git fetch` against `Frank-Yong/DocDownOps` are verified.
 
 ### Delivery Plan (V1)
 
@@ -208,16 +213,16 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Document node01 primary and node02 standby setup for the DocDownOps polling runner service.
   - [x] Install DocDownOps polling runner service on node01.
   - [x] Install DocDownOps polling runner service on node02.
-  - [ ] Enable/start node01 DocDownOps polling runner service.
+  - [x] Enable/start node01 DocDownOps polling runner service.
   - [x] Disable/stop node02 DocDownOps polling runner service as standby default.
-  - [ ] Configure `DOCDOWN_JOB_EXECUTOR` on node01.
-  - [ ] Configure `DOCDOWN_JOB_EXECUTOR` on node02.
+  - [x] Configure `DOCDOWN_JOB_EXECUTOR` on node01.
+  - [x] Configure `DOCDOWN_JOB_EXECUTOR` on node02.
 
 3. GitHub Writeback Credentials
-  - [ ] Choose node-local writeback auth strategy for DocDownOps (`GitHub App`, fine-grained PAT, or SSH key).
-  - [ ] Provision write-capable credentials on node01 for DocDownOps repo updates.
-  - [ ] Provision write-capable credentials on node02 for failover operation.
-  - [ ] Store credentials outside the repository in a host-local secure location (environment file, credential helper, or app flow).
+  - [x] Choose node-local writeback auth strategy for DocDownOps (`GitHub App`, fine-grained PAT, or SSH key).
+  - [x] Provision write-capable credentials on node01 for DocDownOps repo updates.
+  - [x] Provision write-capable credentials on node02 for failover operation.
+  - [x] Store credentials outside the repository in a host-local secure location (environment file, credential helper, or app flow).
   - [ ] Verify node01 can authenticate for fetch/pull/push against DocDownOps.
   - [ ] Verify node02 can authenticate for fetch/pull/push against DocDownOps.
 
@@ -256,8 +261,10 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 ### Immediate Next Steps
 
-1. Pull/install repo-managed executor script `scripts/docdown-execute-manifest.sh` on node01 and node02 and point `DOCDOWN_JOB_EXECUTOR` to it.
-2. Create `/etc/default/docdownops-runner` on node02.
+1. Install the GitHub App token helper at a permanent host path and replace the temporary `/tmp/github-app-token.sh` usage on node01 and node02.
+2. Verify authenticated `git pull` and `git push` on node01 and node02 before wiring writeback into the polling runner.
+3. Implement and validate controlled git sync/writeback for `jobs/*` and `status/*` updates from the polling runner.
+4. Submit a real DocDownOps job through `workflow_dispatch` and verify end-to-end remote state progression and result publication.
 3. Start `docdownops-runner.service` on node01 and verify it reaches `active (running)`.
 4. Configure and verify writable GitHub credentials for DocDownOps writeback on node01 and node02.
 5. Run one end-to-end DocDownOps queued job and verify remote status/result publication.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -205,8 +205,8 @@ Per job root:
 1. [x] Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
 2. [x] Implement submit path (`workflow_dispatch` + JSON manifest validation).
 3. [x] Implement claim/lock behavior in the DocDownOps polling runner service.
-4. [ ] Implement conversion executor with standardized artifact layout.
-5. [ ] Publish status transitions and result links to submitter-visible location via DocDownOps polling runner integration.
+4. [x] Implement conversion executor with standardized artifact layout.
+5. [x] Publish status transitions and result links to submitter-visible location via DocDownOps polling runner integration.
 6. [x] Add runbook for restart, stuck-job recovery, and replay by `job_id`.
 7. [x] Validate Task 10.1 node01 primary CD runner end-to-end (registration, prerequisites, and smoke deploy).
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -273,10 +273,10 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Add replay-by-`job_id` operational procedure for failed jobs.
+3. Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
 
 8. Operational Hardening
-  - [ ] Add stuck-job detection for aged entries in `jobs/running/`.
+  - [x] Add stuck-job detection for aged entries in `jobs/running/`.
   - [ ] Add replay-by-`job_id` operational procedure for failed jobs.
   - [ ] Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
   - [ ] Define alert thresholds for queue depth, job age, and repeated push failures.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -181,14 +181,22 @@ Per job root:
   - Repo-managed executor script is installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
   - `runner-loop.sh` was corrected so `claim-job.sh` exit code `3` (`no queued jobs`) is treated as idle sleep instead of service failure.
   - GitHub App credentials are installed outside the repository and readable by `docdown-runner`.
-  - GitHub App token minting and authenticated `git fetch` against `Frank-Yong/DocDownOps` are verified.
+  - GitHub App token minting and repo-managed authenticated `git fetch`, `git pull`, and `git push` are verified.
+  - `scripts/docdown-execute-manifest.sh` now tracks executable mode from Git and the local checkout can be kept clean.
+  - Writeback sync settings are appended in `/etc/default/docdownops-runner` (`DOCDOWN_GIT_SYNC_ENABLED=true`, deterministic runner commit identity).
+  - Temporary GitHub App validation branches have been deleted from origin.
+  - Post-restart health with authenticated sync enabled is verified: periodic authenticated refresh shows `Already up to date.` and idle polling shows `No queued jobs available to claim.` while the service stays `active (running)`.
 - Task 10.2 / node02:
   - DocDownOps repo clone exists.
   - `/etc/default/docdownops-runner` exists.
   - `docdownops-runner.service` is installed, disabled, and inactive as intended for standby.
   - Repo-managed executor script is installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
   - GitHub App credentials are installed outside the repository and readable by `docdown-runner`.
-  - GitHub App token minting and authenticated `git fetch` against `Frank-Yong/DocDownOps` are verified.
+  - GitHub App token minting and repo-managed authenticated `git fetch`, `git pull`, and `git push` are verified.
+  - `scripts/docdown-execute-manifest.sh` now tracks executable mode from Git and the local checkout can be kept clean.
+  - Writeback sync settings are appended in `/etc/default/docdownops-runner` (`DOCDOWN_GIT_SYNC_ENABLED=true`, deterministic runner commit identity).
+  - Temporary GitHub App validation branches have been deleted from origin.
+  - Service is still intended to remain disabled/inactive as standby after the environment update.
 
 ### Delivery Plan (V1)
 
@@ -223,8 +231,8 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Provision write-capable credentials on node01 for DocDownOps repo updates.
   - [x] Provision write-capable credentials on node02 for failover operation.
   - [x] Store credentials outside the repository in a host-local secure location (environment file, credential helper, or app flow).
-  - [ ] Verify node01 can authenticate for fetch/pull/push against DocDownOps.
-  - [ ] Verify node02 can authenticate for fetch/pull/push against DocDownOps.
+  - [x] Verify node01 can authenticate for fetch/pull/push against DocDownOps.
+  - [x] Verify node02 can authenticate for fetch/pull/push against DocDownOps.
 
 4. Polling Runner Writeback And Sync
   - [ ] Implement controlled git sync/writeback for the DocDownOps polling runner service.
@@ -261,13 +269,9 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 ### Immediate Next Steps
 
-1. Install the GitHub App token helper at a permanent host path and replace the temporary `/tmp/github-app-token.sh` usage on node01 and node02.
-2. Verify authenticated `git pull` and `git push` on node01 and node02 before wiring writeback into the polling runner.
-3. Implement and validate controlled git sync/writeback for `jobs/*` and `status/*` updates from the polling runner.
-4. Submit a real DocDownOps job through `workflow_dispatch` and verify end-to-end remote state progression and result publication.
-3. Start `docdownops-runner.service` on node01 and verify it reaches `active (running)`.
-4. Configure and verify writable GitHub credentials for DocDownOps writeback on node01 and node02.
-5. Run one end-to-end DocDownOps queued job and verify remote status/result publication.
+1. Submit a real DocDownOps job through `workflow_dispatch` and verify end-to-end remote state progression and result publication.
+2. Confirm `jobs/running -> jobs/done` and `status/*` updates are written back to origin by the sync-enabled polling runner.
+3. Test failover by stopping node01, enabling node02, and confirming the same authenticated sync/writeback behavior on the standby node.
 
 8. Operational Hardening
   - [ ] Add stuck-job detection for aged entries in `jobs/running/`.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -165,6 +165,26 @@ Per job root:
 - Task 10.1: node02 remains configured as CD standby/fallback and should stay disabled unless failover is needed.
 - Task 10.2: DocDownOps runner-loop setup runbook is created for node01 primary and node02 standby local job execution.
 
+### Current Host Status (2026-04-15)
+
+- Task 10.1 / node01:
+  - GitHub Actions CD runner service is installed, enabled, and running.
+  - Deploy prerequisites are confirmed present: `python3`, `qpdf`, `pandoc`, `gs`, `/usr/local/bin/docdown-activate-release`, and `/opt/docdown/shared/wheelhouse`.
+- Task 10.1 / node02:
+  - GitHub Actions CD runner service is installed, disabled, and inactive as intended for standby.
+  - Deploy prerequisites are confirmed present: `python3`, `qpdf`, `pandoc`, `gs`, `/usr/local/bin/docdown-activate-release`, and `/opt/docdown/shared/wheelhouse`.
+- Task 10.2 / node01:
+  - DocDownOps repo clone exists.
+  - `/etc/default/docdownops-runner` exists.
+  - `docdownops-runner.service` is installed and enabled.
+  - `docdownops-runner.service` is currently inactive.
+  - Repo-managed executor script should be installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+- Task 10.2 / node02:
+  - DocDownOps repo clone exists.
+  - `docdownops-runner.service` is installed, disabled, and inactive as intended for standby.
+  - `/etc/default/docdownops-runner` is missing.
+  - Repo-managed executor script should be installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
+
 ### Delivery Plan (V1)
 
 1. [x] Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
@@ -174,6 +194,79 @@ Per job root:
 5. [ ] Publish status transitions and result links to submitter-visible location via DocDownOps polling runner integration.
 6. [x] Add runbook for restart, stuck-job recovery, and replay by `job_id`.
 7. [x] Validate Task 10.1 node01 primary CD runner end-to-end (registration, prerequisites, and smoke deploy).
+
+### Detailed Delivery Checklist
+
+Use this checklist as the operational breakdown for the remaining Task 10.2 work.
+
+1. Control Plane Baseline
+  - [x] Create DocDownOps repo structure and queue/state layout.
+  - [x] Add GitHub-facing submit workflow for queued job creation.
+  - [x] Define job manifest contract and status model.
+
+2. Host And Service Setup
+  - [x] Document node01 primary and node02 standby setup for the DocDownOps polling runner service.
+  - [x] Install DocDownOps polling runner service on node01.
+  - [x] Install DocDownOps polling runner service on node02.
+  - [ ] Enable/start node01 DocDownOps polling runner service.
+  - [x] Disable/stop node02 DocDownOps polling runner service as standby default.
+  - [ ] Configure `DOCDOWN_JOB_EXECUTOR` on node01.
+  - [ ] Configure `DOCDOWN_JOB_EXECUTOR` on node02.
+
+3. GitHub Writeback Credentials
+  - [ ] Choose node-local writeback auth strategy for DocDownOps (`GitHub App`, fine-grained PAT, or SSH key).
+  - [ ] Provision write-capable credentials on node01 for DocDownOps repo updates.
+  - [ ] Provision write-capable credentials on node02 for failover operation.
+  - [ ] Store credentials outside the repository in a host-local secure location (environment file, credential helper, or app flow).
+  - [ ] Verify node01 can authenticate for fetch/pull/push against DocDownOps.
+  - [ ] Verify node02 can authenticate for fetch/pull/push against DocDownOps.
+
+4. Polling Runner Writeback And Sync
+  - [ ] Implement controlled git sync/writeback for the DocDownOps polling runner service.
+  - [ ] Fetch/rebase before local state updates are pushed.
+  - [ ] Commit status/history/manifest transitions with predictable commit messages.
+  - [ ] Push `jobs/running -> jobs/done` and `status/*` updates back to origin.
+  - [ ] Handle push conflicts/retries safely when multiple writers exist.
+  - [ ] Document recovery procedure for failed local commit/push operations.
+
+5. Conversion Executor Integration
+  - [ ] Implement `DOCDOWN_JOB_EXECUTOR` command contract for manifest-driven execution.
+  - [ ] Materialize per-job workspace under `/opt/docdown/workspace/jobs/<job_id>`.
+  - [ ] Stage input PDF from declared source.
+  - [ ] Run DocDown conversion with controlled config/options.
+  - [ ] Write standardized artifacts (`input/`, `output/`, `logs/`, `summary.json`).
+  - [ ] Classify failures as transient vs deterministic.
+  - [ ] Emit result URL or pointer when available.
+
+6. Status And Result Publication
+  - [ ] Publish `running`, `succeeded`, `failed`, and `retrying` states back to DocDownOps origin.
+  - [ ] Preserve attempt counts across retries.
+  - [ ] Append status transitions to `status/history/<job_id>.jsonl`.
+  - [ ] Publish submitter-visible result link (`artifact`, `commit`, or `pr`).
+  - [ ] Ensure failed jobs include a usable diagnostic message/log pointer.
+
+7. End-To-End Validation
+  - [ ] Submit a real DocDownOps job through `workflow_dispatch`.
+  - [ ] Verify node01 DocDownOps polling runner service claims the queued job.
+  - [ ] Verify status progression `queued -> running -> succeeded|failed` in the remote DocDownOps repo.
+  - [ ] Verify terminal manifest lands in `jobs/done/` in the remote DocDownOps repo.
+  - [ ] Verify result pointer is accessible to submitter.
+  - [ ] Test failover by stopping node01 DocDownOps polling runner service and activating node02.
+  - [ ] Confirm node02 can continue processing with the same credentials and writeback flow.
+
+### Immediate Next Steps
+
+1. Pull/install repo-managed executor script `scripts/docdown-execute-manifest.sh` on node01 and node02 and point `DOCDOWN_JOB_EXECUTOR` to it.
+2. Create `/etc/default/docdownops-runner` on node02.
+3. Start `docdownops-runner.service` on node01 and verify it reaches `active (running)`.
+4. Configure and verify writable GitHub credentials for DocDownOps writeback on node01 and node02.
+5. Run one end-to-end DocDownOps queued job and verify remote status/result publication.
+
+8. Operational Hardening
+  - [ ] Add stuck-job detection for aged entries in `jobs/running/`.
+  - [ ] Add replay-by-`job_id` operational procedure for failed jobs.
+  - [ ] Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
+  - [ ] Define alert thresholds for queue depth, job age, and repeated push failures.
 
 ## References
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -242,7 +242,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Commit status/history/manifest transitions with predictable commit messages.
   - [x] Push `jobs/running -> jobs/done` and `status/*` updates back to origin.
   - [ ] Handle push conflicts/retries safely when multiple writers exist.
-  - [ ] Document recovery procedure for failed local commit/push operations.
+  - [x] Document recovery procedure for failed local commit/push operations.
 
 5. Conversion Executor Integration
   - [x] Implement `DOCDOWN_JOB_EXECUTOR` command contract for manifest-driven execution.
@@ -272,7 +272,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 ### Immediate Next Steps
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
-2. Add recovery guidance for push conflicts and failed local writeback operations.
+2. Handle push conflicts/retries safely when multiple writers exist.
 3. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
 
 8. Operational Hardening

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -250,7 +250,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Stage input PDF from declared source.
   - [x] Run DocDown conversion with controlled config/options.
   - [x] Write standardized artifacts (`input/`, `output/`, `logs/`, `summary.json`).
-  - [ ] Classify failures as transient vs deterministic.
+  - [x] Classify failures as transient vs deterministic.
   - [x] Emit result URL or pointer when available.
 
 6. Status And Result Publication
@@ -273,7 +273,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Classify failures as transient vs deterministic for retry policy tuning.
+3. Add replay-by-`job_id` operational procedure for failed jobs.
 
 8. Operational Hardening
   - [ ] Add stuck-job detection for aged entries in `jobs/running/`.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -147,9 +147,12 @@ Per job root:
 - Max pages: 1500
 - Max wall-clock per job: 30 minutes
 - Max concurrent jobs per DocDownOps polling runner service: 1 (increase after soak)
-- Retention:
-  - keep last 30 days of artifacts
-  - keep failure logs for 60 days
+- Retention (controlled by DocDownOps runner env knobs; see rollout note for current configured values):
+  - `DOCDOWN_RETENTION_DONE_DAYS` for `jobs/done/` manifests
+  - `DOCDOWN_RETENTION_STATUS_DAYS` for terminal `status/<job_id>.json`
+  - `DOCDOWN_RETENTION_STATUS_HISTORY_DAYS` for `status/history/<job_id>.jsonl`
+  - `DOCDOWN_RETENTION_RESULTS_DAYS` for `results/<job_id>/` artifacts (including failure logs)
+  - Initial deployed defaults: 30 days for all of the above (aligned with rollout note `DOCDOWN_RETENTION_*_DAYS=30`).
 
 ### Integration Boundary With Task 10.1
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -12,14 +12,14 @@ This task focuses on runtime operations for conversion jobs, not repository vali
 
 ## Acceptance Criteria
 
-- [ ] A conversion workflow model is documented (intake -> queue -> worker -> artifacts -> status).
-- [ ] Job states are defined and used consistently (`queued`, `running`, `succeeded`, `failed`, `retrying`).
-- [ ] Retry policy distinguishes transient failures from deterministic failures.
-- [ ] Artifact storage layout is defined for traceability (input, final markdown, logs, summary per job).
-- [ ] Idempotency strategy is documented (input hash + options).
-- [ ] Operational limits are documented (max input size/pages, timeout policy, concurrency caps).
-- [ ] A runbook exists for start/stop/restart, diagnosis, and recovery for the conversion worker/service.
-- [ ] CI/CD handoff to runtime workflow is documented (what CD deploys and what it restarts).
+- [x] A conversion workflow model is documented (intake -> queue -> worker -> artifacts -> status).
+- [x] Job states are defined and used consistently (`queued`, `running`, `succeeded`, `failed`, `retrying`).
+- [x] Retry policy distinguishes transient failures from deterministic failures.
+- [x] Artifact storage layout is defined for traceability (input, final markdown, logs, summary per job).
+- [x] Idempotency strategy is documented (input hash + options).
+- [x] Operational limits are documented (max input size/pages, timeout policy, concurrency caps).
+- [x] A runbook exists for start/stop/restart, diagnosis, and recovery for the conversion worker/service.
+- [x] CI/CD handoff to runtime workflow is documented (what CD deploys and what it restarts).
 
 ## Implementation Notes
 
@@ -153,12 +153,12 @@ Per job root:
 
 ### Delivery Plan (V1)
 
-1. Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
-2. Implement submit path (`workflow_dispatch` + JSON manifest validation).
-3. Implement claim/lock behavior on local runner.
-4. Implement conversion executor with standardized artifact layout.
-5. Publish status transitions and result links to submitter-visible location.
-6. Add runbook for restart, stuck-job recovery, and replay by `job_id`.
+1. [x] Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
+2. [x] Implement submit path (`workflow_dispatch` + JSON manifest validation).
+3. [x] Implement claim/lock behavior on local runner.
+4. [ ] Implement conversion executor with standardized artifact layout.
+5. [ ] Publish status transitions and result links to submitter-visible location via runner integration.
+6. [x] Add runbook for restart, stuck-job recovery, and replay by `job_id`.
 
 ## References
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -273,12 +273,12 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
+3. Add replay-by-`job_id` operational procedure for failed jobs.
 
 8. Operational Hardening
   - [x] Add stuck-job detection for aged entries in `jobs/running/`.
   - [ ] Add replay-by-`job_id` operational procedure for failed jobs.
-  - [ ] Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
+  - [x] Add retention/cleanup policy for old `jobs/done`, `status`, and artifacts.
   - [ ] Define alert thresholds for queue depth, job age, and repeated push failures.
 
 ## References

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -151,6 +151,11 @@ Per job root:
 - Task 10.2 provides runtime conversion orchestration and operations policy.
 - CD should restart or reload the conversion service defined in this task.
 
+### Operational Verification (2026-04-14)
+
+- Node01 is configured as the active self-hosted CD runner and validated with a green smoke deploy.
+- Node02 remains configured as standby/fallback and should stay disabled unless failover is needed.
+
 ### Delivery Plan (V1)
 
 1. [x] Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
@@ -159,6 +164,7 @@ Per job root:
 4. [ ] Implement conversion executor with standardized artifact layout.
 5. [ ] Publish status transitions and result links to submitter-visible location via runner integration.
 6. [x] Add runbook for restart, stuck-job recovery, and replay by `job_id`.
+7. [x] Validate node01 primary CD runner end-to-end (registration, prerequisites, and smoke deploy).
 
 ## References
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -81,7 +81,7 @@ flowchart LR
 
 Job manifest fields:
 
-- `job_id`: unique id (`YYYYMMDDHHMMSS-<shortsha>-<nonce>`)
+- `job_id`: unique id (`YYYYMMDDHHMMSS-<shortsha>`)
 - `submitted_at`, `submitted_by`
 - `source`:
   - `type`: `git` | `upload`

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -187,17 +187,18 @@ Per job root:
   - Temporary GitHub App validation branches have been deleted from origin.
   - Post-restart health with authenticated sync enabled is verified: periodic authenticated refresh shows `Already up to date.` and idle polling shows `No queued jobs available to claim.` while the service stays `active (running)`.
   - First live workflow-dispatched job (`20260415090651-ed80d4`) completed successfully through the sync-enabled runner path.
+  - Controlled failover was validated by stopping/disabling node01, activating node02, and completing a real workflow-dispatched job through the standby node.
 - Task 10.2 / node02:
   - DocDownOps repo clone exists.
   - `/etc/default/docdownops-runner` exists.
-  - `docdownops-runner.service` is installed, disabled, and inactive as intended for standby.
+  - `docdownops-runner.service` is installed and has been validated both as disabled standby and as active failover runner.
   - Repo-managed executor script is installed at `/opt/docdown-ops/releases/docdownops-main/scripts/docdown-execute-manifest.sh`.
   - GitHub App credentials are installed outside the repository and readable by `docdown-runner`.
   - GitHub App token minting and repo-managed authenticated `git fetch`, `git pull`, and `git push` are verified.
   - `scripts/docdown-execute-manifest.sh` now tracks executable mode from Git and the local checkout can be kept clean.
   - Writeback sync settings are appended in `/etc/default/docdownops-runner` (`DOCDOWN_GIT_SYNC_ENABLED=true`, deterministic runner commit identity).
   - Temporary GitHub App validation branches have been deleted from origin.
-  - Service is still intended to remain disabled/inactive as standby after the environment update.
+  - Controlled failover job `20260415102641-543c64` completed successfully through node02 with the same authenticated sync/writeback path and submitter-visible `result_url` publication.
 
 ### Delivery Plan (V1)
 
@@ -265,12 +266,12 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Verify status progression `queued -> running -> succeeded|failed` in the remote DocDownOps repo.
   - [x] Verify terminal manifest lands in `jobs/done/` in the remote DocDownOps repo.
   - [x] Verify result pointer is accessible to submitter.
-  - [ ] Test failover by stopping node01 DocDownOps polling runner service and activating node02.
-  - [ ] Confirm node02 can continue processing with the same credentials and writeback flow.
+  - [x] Test failover by stopping node01 DocDownOps polling runner service and activating node02.
+  - [x] Confirm node02 can continue processing with the same credentials and writeback flow.
 
 ### Immediate Next Steps
 
-1. Test failover by stopping node01, enabling node02, and confirming the same authenticated sync/writeback behavior on the standby node.
+1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Add recovery guidance for push conflicts and failed local writeback operations.
 3. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -155,6 +155,7 @@ Per job root:
 
 - Node01 is configured as the active self-hosted CD runner and validated with a green smoke deploy.
 - Node02 remains configured as standby/fallback and should stay disabled unless failover is needed.
+- DocDownOps runner-loop setup runbook created for node01 primary and node02 standby operation.
 
 ### Delivery Plan (V1)
 
@@ -172,3 +173,4 @@ Per job root:
 - [task-10.1-ci-cd-pipeline.md](task-10.1-ci-cd-pipeline.md)
 - [../technical-design.md](../technical-design.md)
 - [../notes/2026-04-14_07-10-00.md](../notes/2026-04-14_07-10-00.md)
+- [../notes/2026-04-14_16-20-00-docdownops-runner-setup.md](../notes/2026-04-14_16-20-00-docdownops-runner-setup.md)

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -258,7 +258,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Preserve attempt counts across retries.
   - [x] Append status transitions to `status/history/<job_id>.jsonl`.
   - [x] Publish submitter-visible result link (`artifact`, `commit`, or `pr`).
-  - [ ] Ensure failed jobs include a usable diagnostic message/log pointer.
+  - [x] Ensure failed jobs include a usable diagnostic message/log pointer.
 
 7. End-To-End Validation
   - [x] Submit a real DocDownOps job through `workflow_dispatch`.
@@ -273,7 +273,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
 2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
-3. Include a stronger diagnostic pointer for failed jobs.
+3. Classify failures as transient vs deterministic for retry policy tuning.
 
 8. Operational Hardening
   - [ ] Add stuck-job detection for aged entries in `jobs/running/`.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -236,27 +236,27 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Verify node02 can authenticate for fetch/pull/push against DocDownOps.
 
 4. Polling Runner Writeback And Sync
-  - [ ] Implement controlled git sync/writeback for the DocDownOps polling runner service.
-  - [ ] Fetch/rebase before local state updates are pushed.
-  - [ ] Commit status/history/manifest transitions with predictable commit messages.
-  - [ ] Push `jobs/running -> jobs/done` and `status/*` updates back to origin.
+  - [x] Implement controlled git sync/writeback for the DocDownOps polling runner service.
+  - [x] Fetch/rebase before local state updates are pushed.
+  - [x] Commit status/history/manifest transitions with predictable commit messages.
+  - [x] Push `jobs/running -> jobs/done` and `status/*` updates back to origin.
   - [ ] Handle push conflicts/retries safely when multiple writers exist.
   - [ ] Document recovery procedure for failed local commit/push operations.
 
 5. Conversion Executor Integration
-  - [ ] Implement `DOCDOWN_JOB_EXECUTOR` command contract for manifest-driven execution.
-  - [ ] Materialize per-job workspace under `/opt/docdown/workspace/jobs/<job_id>`.
-  - [ ] Stage input PDF from declared source.
-  - [ ] Run DocDown conversion with controlled config/options.
-  - [ ] Write standardized artifacts (`input/`, `output/`, `logs/`, `summary.json`).
+  - [x] Implement `DOCDOWN_JOB_EXECUTOR` command contract for manifest-driven execution.
+  - [x] Materialize per-job workspace under `/opt/docdown/workspace/jobs/<job_id>`.
+  - [x] Stage input PDF from declared source.
+  - [x] Run DocDown conversion with controlled config/options.
+  - [x] Write standardized artifacts (`input/`, `output/`, `logs/`, `summary.json`).
   - [ ] Classify failures as transient vs deterministic.
-  - [ ] Emit result URL or pointer when available.
+  - [x] Emit result URL or pointer when available.
 
 6. Status And Result Publication
-  - [ ] Publish `running`, `succeeded`, `failed`, and `retrying` states back to DocDownOps origin.
+  - [x] Publish `running`, `succeeded`, `failed`, and `retrying` states back to DocDownOps origin.
   - [ ] Preserve attempt counts across retries.
-  - [ ] Append status transitions to `status/history/<job_id>.jsonl`.
-  - [ ] Publish submitter-visible result link (`artifact`, `commit`, or `pr`).
+  - [x] Append status transitions to `status/history/<job_id>.jsonl`.
+  - [x] Publish submitter-visible result link (`artifact`, `commit`, or `pr`).
   - [ ] Ensure failed jobs include a usable diagnostic message/log pointer.
 
 7. End-To-End Validation
@@ -264,15 +264,15 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Verify node01 DocDownOps polling runner service claims the queued job.
   - [x] Verify status progression `queued -> running -> succeeded|failed` in the remote DocDownOps repo.
   - [x] Verify terminal manifest lands in `jobs/done/` in the remote DocDownOps repo.
-  - [ ] Verify result pointer is accessible to submitter.
+  - [x] Verify result pointer is accessible to submitter.
   - [ ] Test failover by stopping node01 DocDownOps polling runner service and activating node02.
   - [ ] Confirm node02 can continue processing with the same credentials and writeback flow.
 
 ### Immediate Next Steps
 
-1. Inspect node01 local workspace for job `20260415090651-ed80d4` and confirm expected artifacts (`output/final.md`, logs, `summary.json`).
-2. Implement publishable result pointer support so successful jobs populate `result_url` in `status/<job_id>.json`.
-3. Test failover by stopping node01, enabling node02, and confirming the same authenticated sync/writeback behavior on the standby node.
+1. Test failover by stopping node01, enabling node02, and confirming the same authenticated sync/writeback behavior on the standby node.
+2. Add recovery guidance for push conflicts and failed local writeback operations.
+3. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
 
 8. Operational Hardening
   - [ ] Add stuck-job detection for aged entries in `jobs/running/`.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -27,11 +27,17 @@ This task focuses on runtime operations for conversion jobs, not repository vali
 
 The goal is to make conversion execution operationally safe in production. CI/CD should deploy and restart runtime components, while this task defines and stabilizes how conversion work is accepted, processed, and observed.
 
+### Terminology And Boundary
+
+- Task 10.1 CD runner: GitHub Actions self-hosted runner on node01 by default, with node02 as fallback for repository deployment workflow.
+- Task 10.2 ops runner: local DocDownOps polling service (`runner-loop.sh`) on node01 by default, with node02 as standby/failover for job execution.
+- These are separate runtime concerns even if they run on the same hosts.
+
 ### Operating Constraint
 
-- Conversion execution remains on a local self-hosted runner in LAN.
+- Conversion execution remains on a local LAN-hosted DocDownOps polling runner/service.
 - Submission and status must be available from anywhere with GitHub access.
-- Therefore, runtime orchestration should use GitHub as the control plane and local runner as the execution plane.
+- Therefore, runtime orchestration should use GitHub as the control plane and the DocDownOps local polling runner service as the execution plane.
 
 ### Recommended V1 Architecture
 
@@ -40,14 +46,14 @@ The goal is to make conversion execution operationally safe in production. CI/CD
   - workflow dispatch
   - issue/PR command
   - CLI that writes job manifests to ops repo
-- Local runner polls/claims jobs from ops repo and performs conversion.
+- DocDownOps local polling runner service polls/claims jobs from ops repo and performs conversion.
 - Results are published back to GitHub (artifacts and/or commit/PR), so submitter can access markdown remotely.
 
 ```mermaid
 flowchart LR
     U[Submitter Anywhere] --> G[GitHub API or Ops Repo]
     G --> Q[Job Manifest Queue]
-    Q --> R[Local LAN Runner Claims Job]
+    Q --> R[DocDownOps Polling Runner Claims Job]
     R --> C[DocDown Conversion]
     C --> A[Result Artifacts and Logs]
     A --> G
@@ -62,7 +68,7 @@ flowchart LR
 - Queue:
   - git-backed job manifests in ops repo (`jobs/queued/*.json`)
 - Worker:
-  - local runner claims by moving manifest to `jobs/running/`
+  - DocDownOps polling runner service claims by moving manifest to `jobs/running/`
   - isolated workdir per job (`/opt/docdown/workspace/jobs/<job_id>`)
 - Artifacts:
   - per-job output tree containing staged input, final markdown, logs, run summary
@@ -140,7 +146,7 @@ Per job root:
 - Max PDF size: 150 MB
 - Max pages: 1500
 - Max wall-clock per job: 30 minutes
-- Max concurrent jobs per runner: 1 (increase after soak)
+- Max concurrent jobs per DocDownOps polling runner service: 1 (increase after soak)
 - Retention:
   - keep last 30 days of artifacts
   - keep failure logs for 60 days
@@ -149,23 +155,25 @@ Per job root:
 
 - Task 10.1 provides CI/CD pipelines and deployment mechanics.
 - Task 10.2 provides runtime conversion orchestration and operations policy.
-- CD should restart or reload the conversion service defined in this task.
+- Task 10.1 CD runs through GitHub Actions on the DocDown self-hosted runner.
+- Task 10.2 execution runs through the DocDownOps local polling runner/service.
+- CD should restart or reload the conversion service defined in this task when that service is part of deployed runtime.
 
 ### Operational Verification (2026-04-14)
 
-- Node01 is configured as the active self-hosted CD runner and validated with a green smoke deploy.
-- Node02 remains configured as standby/fallback and should stay disabled unless failover is needed.
-- DocDownOps runner-loop setup runbook created for node01 primary and node02 standby operation.
+- Task 10.1: node01 is configured as the active GitHub Actions self-hosted CD runner and validated with a green smoke deploy.
+- Task 10.1: node02 remains configured as CD standby/fallback and should stay disabled unless failover is needed.
+- Task 10.2: DocDownOps runner-loop setup runbook is created for node01 primary and node02 standby local job execution.
 
 ### Delivery Plan (V1)
 
 1. [x] Create ops repo structure (`jobs/queued`, `jobs/running`, `jobs/done`, `status`).
 2. [x] Implement submit path (`workflow_dispatch` + JSON manifest validation).
-3. [x] Implement claim/lock behavior on local runner.
+3. [x] Implement claim/lock behavior in the DocDownOps polling runner service.
 4. [ ] Implement conversion executor with standardized artifact layout.
-5. [ ] Publish status transitions and result links to submitter-visible location via runner integration.
+5. [ ] Publish status transitions and result links to submitter-visible location via DocDownOps polling runner integration.
 6. [x] Add runbook for restart, stuck-job recovery, and replay by `job_id`.
-7. [x] Validate node01 primary CD runner end-to-end (registration, prerequisites, and smoke deploy).
+7. [x] Validate Task 10.1 node01 primary CD runner end-to-end (registration, prerequisites, and smoke deploy).
 
 ## References
 

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -241,7 +241,7 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [x] Fetch/rebase before local state updates are pushed.
   - [x] Commit status/history/manifest transitions with predictable commit messages.
   - [x] Push `jobs/running -> jobs/done` and `status/*` updates back to origin.
-  - [ ] Handle push conflicts/retries safely when multiple writers exist.
+  - [x] Handle push conflicts/retries safely when multiple writers exist.
   - [x] Document recovery procedure for failed local commit/push operations.
 
 5. Conversion Executor Integration
@@ -272,8 +272,8 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
 ### Immediate Next Steps
 
 1. Return to normal posture by re-enabling node01 and disabling node02 after the completed failover test.
-2. Handle push conflicts/retries safely when multiple writers exist.
-3. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
+2. Remove the remaining manual username/password prompts from operator-side `git fetch` maintenance on node01/node02.
+3. Preserve attempt counts across retries and include a stronger diagnostic pointer for failed jobs.
 
 8. Operational Hardening
   - [ ] Add stuck-job detection for aged entries in `jobs/running/`.

--- a/docs/plan/task-10.2-conversion-workflow.md
+++ b/docs/plan/task-10.2-conversion-workflow.md
@@ -186,6 +186,7 @@ Per job root:
   - Writeback sync settings are appended in `/etc/default/docdownops-runner` (`DOCDOWN_GIT_SYNC_ENABLED=true`, deterministic runner commit identity).
   - Temporary GitHub App validation branches have been deleted from origin.
   - Post-restart health with authenticated sync enabled is verified: periodic authenticated refresh shows `Already up to date.` and idle polling shows `No queued jobs available to claim.` while the service stays `active (running)`.
+  - First live workflow-dispatched job (`20260415090651-ed80d4`) completed successfully through the sync-enabled runner path.
 - Task 10.2 / node02:
   - DocDownOps repo clone exists.
   - `/etc/default/docdownops-runner` exists.
@@ -259,18 +260,18 @@ Use this checklist as the operational breakdown for the remaining Task 10.2 work
   - [ ] Ensure failed jobs include a usable diagnostic message/log pointer.
 
 7. End-To-End Validation
-  - [ ] Submit a real DocDownOps job through `workflow_dispatch`.
-  - [ ] Verify node01 DocDownOps polling runner service claims the queued job.
-  - [ ] Verify status progression `queued -> running -> succeeded|failed` in the remote DocDownOps repo.
-  - [ ] Verify terminal manifest lands in `jobs/done/` in the remote DocDownOps repo.
+  - [x] Submit a real DocDownOps job through `workflow_dispatch`.
+  - [x] Verify node01 DocDownOps polling runner service claims the queued job.
+  - [x] Verify status progression `queued -> running -> succeeded|failed` in the remote DocDownOps repo.
+  - [x] Verify terminal manifest lands in `jobs/done/` in the remote DocDownOps repo.
   - [ ] Verify result pointer is accessible to submitter.
   - [ ] Test failover by stopping node01 DocDownOps polling runner service and activating node02.
   - [ ] Confirm node02 can continue processing with the same credentials and writeback flow.
 
 ### Immediate Next Steps
 
-1. Submit a real DocDownOps job through `workflow_dispatch` and verify end-to-end remote state progression and result publication.
-2. Confirm `jobs/running -> jobs/done` and `status/*` updates are written back to origin by the sync-enabled polling runner.
+1. Inspect node01 local workspace for job `20260415090651-ed80d4` and confirm expected artifacts (`output/final.md`, logs, `summary.json`).
+2. Implement publishable result pointer support so successful jobs populate `result_url` in `status/<job_id>.json`.
 3. Test failover by stopping node01, enabling node02, and confirming the same authenticated sync/writeback behavior on the standby node.
 
 8. Operational Hardening

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -459,7 +459,7 @@ Memory usage is bounded by the chunk size. A 50-page chunk typically requires < 
 | Environment       | Priority  | Notes                                                        |
 | ----------------- | --------- | ------------------------------------------------------------ |
 | Linux (local)     | Primary   | Ubuntu 22.04+ recommended. All tools available via apt/pip.  |
-| GitHub Actions    | Primary   | PR CI on `ubuntu-latest`; merge-to-main CD on local self-hosted runner. |
+| GitHub Actions    | Primary   | PR CI on `ubuntu-latest`; merge-to-main CD on local self-hosted GitHub Actions runner. |
 | Windows (local)   | Secondary | For debugging. Requires Docker Desktop or WSL2 for GROBID.   |
 
 ### 11.2 Python Version


### PR DESCRIPTION
## Summary
- expand Task 10.2 conversion workflow documentation with implementation status, rollout notes, and operational follow-up
- add and update DocDownOps runner setup notes covering deployment, verification, failover, and replay procedures
- refresh workspace configuration and related docs to match the current DocDown and DocDownOps workflow

## Validation
- documentation updates only
- operational rollout and smoke-test details recorded in the updated notes and task plan