### PR TITLE
Fix critical OSError handling in CLI conversion and workdir staging

### DIFF
--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -231,7 +231,7 @@ def main(
                 )
             )
             continue
-        except (PandocError, CleanupError) as exc:
+        except (PandocError, CleanupError, OSError) as exc:
             logger.error("Markdown conversion/cleanup failed for chunk-%04d: %s", result.chunk_number, exc)
             chunk_results.append(
                 ChunkResult(

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -232,7 +232,7 @@ def main(
             )
             continue
         except (PandocError, CleanupError, OSError) as exc:
-            logger.error("Markdown conversion/cleanup failed for chunk-%04d: %s", result.chunk_number, exc)
+            logger.exception("Markdown conversion/cleanup failed for chunk-%04d: %s", result.chunk_number, exc)
             chunk_results.append(
                 ChunkResult(
                     chunk_number=result.chunk_number,

--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -232,7 +232,7 @@ def main(
             )
             continue
         except (PandocError, CleanupError, OSError) as exc:
-            logger.exception("Markdown conversion/cleanup failed for chunk-%04d: %s", result.chunk_number, exc)
+            logger.error("Markdown conversion/cleanup failed for chunk-%04d: %s", result.chunk_number, exc)
             chunk_results.append(
                 ChunkResult(
                     chunk_number=result.chunk_number,

--- a/docdown/workdir.py
+++ b/docdown/workdir.py
@@ -162,8 +162,11 @@ def _copy_manifest_matches(source: Path, target: Path, manifest_path: Path) -> b
     if not isinstance(expected_source, dict) or not isinstance(expected_target, dict):
         return False
 
-    current_source = _source_fingerprint(source)
-    current_target = _target_fingerprint(target)
+    try:
+        current_source = _source_fingerprint(source)
+        current_target = _target_fingerprint(target)
+    except OSError:
+        return False
     return current_source == expected_source and current_target == expected_target
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,13 +244,6 @@ def test_cli_run_summary_counts_extraction_failures(tmp_path, monkeypatch):
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code == 0
-    assert call_count["count"] == 2
-    chunk_2_markdown = tmp_path / "out" / "markdown" / "chunk-0002.md"
-    assert chunk_2_markdown.exists()
-    assert chunk_2_markdown.read_text(encoding="utf-8") == "# ok"
-    assert "Chunks:         2" in result.stderr
-    assert "Successful:     1" in result.stderr
-    assert "Failed:         1 (chunk-0001: disk full)" in result.stderr
     assert "Chunks:         2" in result.stderr
     assert "Successful:     1" in result.stderr
     assert "Failed:         1 (chunk-0002: extractor timeout)" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,8 +373,6 @@ def test_cli_continues_when_conversion_hits_oserror_for_one_chunk(tmp_path, monk
     call_count = {"count": 0}
 
     def _fake_convert(input_path, output_path, **kwargs):
-        _ = input_path
-        _ = kwargs
         call_count["count"] += 1
         if call_count["count"] == 1:
             raise OSError("disk full")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,10 +244,6 @@ def test_cli_run_summary_counts_extraction_failures(tmp_path, monkeypatch):
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code == 0
-    assert call_count["count"] == 2
-    chunk_2_markdown = tmp_path / "out" / "markdown" / "chunk-0002.md"
-    assert chunk_2_markdown.exists()
-    assert chunk_2_markdown.read_text(encoding="utf-8") == "# ok"
     assert "Chunks:         2" in result.stderr
     assert "Successful:     1" in result.stderr
     assert "Failed:         1 (chunk-0002: extractor timeout)" in result.stderr
@@ -339,6 +335,10 @@ def test_cli_continues_when_cleanup_hits_invalid_utf8_for_one_chunk(tmp_path, mo
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code == 0
+    assert call_count["count"] == 2
+    chunk_2_markdown = tmp_path / "out" / "markdown" / "chunk-0002.md"
+    assert chunk_2_markdown.exists()
+    assert chunk_2_markdown.read_text(encoding="utf-8") == "# ok"
 
 
 def test_cli_continues_when_conversion_hits_oserror_for_one_chunk(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -394,6 +394,13 @@ def test_cli_continues_when_conversion_hits_oserror_for_one_chunk(tmp_path, monk
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code == 0
+    assert call_count["count"] == 2
+    chunk_2_markdown = tmp_path / "out" / "markdown" / "chunk-0002.md"
+    assert chunk_2_markdown.exists()
+    assert chunk_2_markdown.read_text(encoding="utf-8") == "# ok"
+    assert "Chunks:         2" in result.stderr
+    assert "Successful:     1" in result.stderr
+    assert "Failed:         1 (chunk-0001: disk full)" in result.stderr
 
 
 def test_cli_surfaces_merge_errors(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,6 +337,61 @@ def test_cli_continues_when_cleanup_hits_invalid_utf8_for_one_chunk(tmp_path, mo
     assert result.exit_code == 0
 
 
+def test_cli_continues_when_conversion_hits_oserror_for_one_chunk(tmp_path, monkeypatch):
+    dummy_pdf = tmp_path / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+    extracted_1 = tmp_path / "out" / "extracted" / "chunk-0001.xml"
+    extracted_2 = tmp_path / "out" / "extracted" / "chunk-0002.xml"
+
+    monkeypatch.setattr(
+        "docdown.cli.validate_pdf",
+        lambda *args, **kwargs: SimpleNamespace(page_count=2, file_size_bytes=dummy_pdf.stat().st_size),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.split_pdf",
+        lambda *args, **kwargs: SimpleNamespace(
+            chunk_count=2,
+            chunk_paths=(
+                tmp_path / "out" / "chunks" / "chunk-0001.pdf",
+                tmp_path / "out" / "chunks" / "chunk-0002.pdf",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "docdown.cli.orchestrate_extraction",
+        lambda *args, **kwargs: [
+            SimpleNamespace(chunk_number=1, success=True, output_path=extracted_1, extractor="grobid"),
+            SimpleNamespace(chunk_number=2, success=True, output_path=extracted_2, extractor="grobid"),
+        ],
+    )
+    monkeypatch.setattr("docdown.cli.ensure_pandoc_available", lambda *args, **kwargs: None)
+
+    call_count = {"count": 0}
+
+    def _fake_convert(input_path, output_path, **kwargs):
+        _ = input_path
+        _ = kwargs
+        call_count["count"] += 1
+        if call_count["count"] == 1:
+            raise OSError("disk full")
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_text("# ok", encoding="utf-8")
+        return Path(output_path)
+
+    monkeypatch.setattr("docdown.cli.convert_to_markdown", _fake_convert)
+    monkeypatch.setattr("docdown.cli.cleanup_markdown_file", lambda *args, **kwargs: Path(args[0]))
+    monkeypatch.setattr(
+        "docdown.cli.validate_chunk",
+        lambda *args, **kwargs: SimpleNamespace(valid=True, warnings=(), errors=()),
+    )
+    monkeypatch.setattr("docdown.cli.generate_toc", _fake_generate_toc)
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
+
+    assert result.exit_code == 0
+
+
 def test_cli_surfaces_merge_errors(tmp_path, monkeypatch):
     dummy_pdf = tmp_path / "test.pdf"
     dummy_pdf.write_bytes(b"%PDF-1.4 dummy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,13 @@ def test_cli_run_summary_counts_extraction_failures(tmp_path, monkeypatch):
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code == 0
+    assert call_count["count"] == 2
+    chunk_2_markdown = tmp_path / "out" / "markdown" / "chunk-0002.md"
+    assert chunk_2_markdown.exists()
+    assert chunk_2_markdown.read_text(encoding="utf-8") == "# ok"
+    assert "Chunks:         2" in result.stderr
+    assert "Successful:     1" in result.stderr
+    assert "Failed:         1 (chunk-0001: disk full)" in result.stderr
     assert "Chunks:         2" in result.stderr
     assert "Successful:     1" in result.stderr
     assert "Failed:         1 (chunk-0002: extractor timeout)" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,10 @@ def test_cli_run_summary_counts_extraction_failures(tmp_path, monkeypatch):
     result = runner.invoke(main, [str(dummy_pdf), "-o", str(tmp_path / "out")])
 
     assert result.exit_code == 0
+    assert call_count["count"] == 2
+    chunk_2_markdown = tmp_path / "out" / "markdown" / "chunk-0002.md"
+    assert chunk_2_markdown.exists()
+    assert chunk_2_markdown.read_text(encoding="utf-8") == "# ok"
     assert "Chunks:         2" in result.stderr
     assert "Successful:     1" in result.stderr
     assert "Failed:         1 (chunk-0002: extractor timeout)" in result.stderr

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -94,10 +94,6 @@ def test_stage_input_falls_back_when_manifest_fingerprint_raises_oserror(tmp_pat
     copy_calls = 0
 
     def _failing_symlink(self, target, *args, **kwargs):
-        _ = self
-        _ = target
-        _ = args
-        _ = kwargs
         raise OSError("symlink disabled")
 
     def _counting_copy(src, dst, *, follow_symlinks=True):

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -67,7 +67,7 @@ def test_stage_input_copy_fallback_is_idempotent(tmp_path, monkeypatch):
     original_copy2 = workdir_module.shutil.copy2
     copy_calls = 0
 
-    def _failing_symlink(self, target):
+    def _failing_symlink(self, target, *args, **kwargs):
         raise OSError("symlink disabled")
 
     def _counting_copy(src, dst, *, follow_symlinks=True):
@@ -93,9 +93,11 @@ def test_stage_input_falls_back_when_manifest_fingerprint_raises_oserror(tmp_pat
     original_copy2 = workdir_module.shutil.copy2
     copy_calls = 0
 
-    def _failing_symlink(self, target):
+    def _failing_symlink(self, target, *args, **kwargs):
         _ = self
         _ = target
+        _ = args
+        _ = kwargs
         raise OSError("symlink disabled")
 
     def _counting_copy(src, dst, *, follow_symlinks=True):
@@ -238,7 +240,7 @@ def test_stage_input_wraps_copy_oserror(tmp_path, monkeypatch):
     workdir = WorkDir(tmp_path / "output")
     workdir.ensure_structure()
 
-    def _failing_symlink(self, target):
+    def _failing_symlink(self, target, *args, **kwargs):
         raise OSError("symlink disabled")
 
     def _failing_copy(src, dst, *, follow_symlinks=True):

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -85,6 +85,48 @@ def test_stage_input_copy_fallback_is_idempotent(tmp_path, monkeypatch):
     assert copy_calls == 1
 
 
+def test_stage_input_falls_back_when_manifest_fingerprint_raises_oserror(tmp_path, monkeypatch):
+    source = tmp_path / "source.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+
+    workdir = WorkDir(tmp_path / "output")
+    original_copy2 = workdir_module.shutil.copy2
+    copy_calls = 0
+
+    def _failing_symlink(self, target):
+        _ = self
+        _ = target
+        raise OSError("symlink disabled")
+
+    def _counting_copy(src, dst, *, follow_symlinks=True):
+        nonlocal copy_calls
+        copy_calls += 1
+        return original_copy2(src, dst, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(Path, "symlink_to", _failing_symlink)
+    monkeypatch.setattr("docdown.workdir.shutil.copy2", _counting_copy)
+
+    first = workdir.stage_input(source)
+    assert copy_calls == 1
+
+    original_source_fingerprint = workdir_module._source_fingerprint
+    fingerprint_calls = {"count": 0}
+
+    def _raise_once_fingerprint(path):
+        fingerprint_calls["count"] += 1
+        if fingerprint_calls["count"] == 1:
+            raise OSError("stat failed")
+        return original_source_fingerprint(path)
+
+    monkeypatch.setattr("docdown.workdir._source_fingerprint", _raise_once_fingerprint)
+
+    second = workdir.stage_input(source)
+
+    assert second == first
+    assert second.exists()
+    assert copy_calls == 2
+
+
 def test_artifact_path_generation_for_chunk_outputs(tmp_path):
     workdir = WorkDir(tmp_path / "output")
 


### PR DESCRIPTION
## Summary
- catch OSError in the CLI conversion/cleanup loop so a single chunk I/O failure does not crash the whole run
- add regression test covering per-chunk OSError handling in conversion path
- guard workdir copy-manifest fingerprint evaluation against OSError and fall back to re-copy
- add regression test verifying stage_input fallback behavior when fingerprinting fails

## Validation
- pytest -q tests/test_cli.py tests/test_workdir.py
- result: 35 passed

Closes #25
Closes #26