### PR TITLE
fix(config): validate grobid_url scheme and host

### DIFF
--- a/docdown/config.py
+++ b/docdown/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from urllib.parse import urlparse
 
 
 _VALID_EXTRACTORS = {"grobid", "pdfminer"}
@@ -220,6 +221,12 @@ def _validate_semantics(cfg: Config) -> None:
         raise ConfigError(f"fallback_extractor must be one of: {sorted(_VALID_EXTRACTORS)}")
     if cfg.toc_depth < 1 or cfg.toc_depth > 6:
         raise ConfigError("toc_depth must be between 1 and 6.")
+    parsed_grobid = urlparse(cfg.grobid_url)
+    if parsed_grobid.scheme not in ("http", "https") or not parsed_grobid.netloc:
+        raise ConfigError(
+            f"grobid_url must be an http(s) URL with a host, got: {cfg.grobid_url!r}"
+        )
+
     if cfg.log_level not in _VALID_LOG_LEVELS:
         raise ConfigError(f"log_level must be one of: {sorted(_VALID_LOG_LEVELS)}")
     if not math.isfinite(cfg.validation.min_output_ratio):


### PR DESCRIPTION
## Summary

Fixes #60 — grobid_url accepted without URL-shape validation

## Problem

`docdown/config.py` accepted `grobid_url` as an arbitrary string with no validation. Typos like `htttp://grobid:8070` or `grobid:8070` (missing scheme) passed config validation and failed later with cryptic HTTP errors.

## Solution

Added URL validation using `urlparse` in `_validate_semantics()`:
- Check scheme is `http` or `https`
- Check netloc (host) is non-empty

## Testing

Valid URLs pass: `http://localhost:8070`, `https://grobid.example.com`
Invalid URLs are rejected with clear error:
- `htttp://grobid:8070` → "grobid_url must be an http(s) URL with a host, got: 'htttp://grobid:8070'"
- `grobid:8070` → "grobid_url must be an http(s) URL with a host, got: 'grobid:8070'"

## Changed

- `docdown/config.py`: Added `from urllib.parse import urlparse` import, added validation in `_validate_semantics()`
- 1 file changed, +7/-0