### PR TITLE
fix: add bounds check on chunk_number before indexing chunk_paths

### DIFF
--- a/docdown/cli.py
+++ b/docdown/cli.py
@@ -252,6 +252,11 @@ def main(
         else:
             extractor_name = str(extractor_used) if extractor_used is not None else None
 
+        if not (1 <= result.chunk_number <= len(split_result.chunk_paths)):
+            raise click.ClickException(
+                f"Chunk number {result.chunk_number} out of range (1..{len(split_result.chunk_paths)})"
+            )
+
         chunk_validation = validate_chunk(
             markdown_path,
             split_result.chunk_paths[result.chunk_number - 1],


### PR DESCRIPTION
Prevents IndexError when chunk_number=0 (or out of range) accesses split_result.chunk_paths, which silently picked the last chunk instead of raising an error.

Closes #59